### PR TITLE
Wire Adapt this recipe for cooks

### DIFF
--- a/src/app/recipe/[slug]/_components/AdaptThisRecipe.tsx
+++ b/src/app/recipe/[slug]/_components/AdaptThisRecipe.tsx
@@ -17,16 +17,43 @@ import { AuthGateModal } from "./AuthGateModal";
 
 type DifficultyLevel = "EASY" | "MEDIUM" | "HARD";
 
+export type IngredientSwap = {
+  originalIngredientId: number;
+  originalName: string;
+  substitutes: Array<{
+    ingredientId: number;
+    ingredientName: string;
+    quantity: number;
+    unit: string;
+    notes: string | null;
+  }>;
+};
+
 interface AdaptThisRecipeProps {
   servings: number;
   onServingsChange: (servings: number) => void;
   difficulty?: DifficultyLevel;
   onDifficultyChange?: (difficulty: DifficultyLevel) => void;
   hasV2Data?: boolean;
+  swaps?: IngredientSwap[];
 }
 
 type TimeOption = "quick" | "standard" | "slow";
 type DifficultyOption = "beginner" | "confident";
+
+/**
+ * Formats a swap quantity for display.
+ * @param quantity - Numeric quantity
+ * @param unit - Unit string
+ * @returns Formatted quantity string
+ */
+function formatSwapQuantity(quantity: number, unit: string): string {
+  const formatted =
+    quantity % 1 === 0
+      ? quantity.toString()
+      : quantity.toFixed(2).replace(/\.?0+$/, "");
+  return unit ? `${formatted} ${unit}` : formatted;
+}
 
 /**
  * Adapt this recipe card - the key differentiator feature.
@@ -38,6 +65,7 @@ type DifficultyOption = "beginner" | "confident";
  * @param difficulty - Current difficulty level (v2)
  * @param onDifficultyChange - Callback when difficulty changes (v2)
  * @param hasV2Data - Whether this recipe has v2 difficulty variations
+ * @param swaps - Ingredient substitution suggestions
  */
 export function AdaptThisRecipe({
   servings,
@@ -45,6 +73,7 @@ export function AdaptThisRecipe({
   difficulty = "MEDIUM",
   onDifficultyChange,
   hasV2Data = false,
+  swaps = [],
 }: AdaptThisRecipeProps): JSX.Element {
   const { isSignedIn, isLoaded } = useUser();
   const [showAuthGate, setShowAuthGate] = useState(false);
@@ -173,6 +202,7 @@ export function AdaptThisRecipe({
             >
               <ArrowRightLeft className="mr-2 h-4 w-4" />
               See swaps
+              {swaps.length > 0 ? ` (${swaps.length})` : ""}
             </Button>
           </div>
 
@@ -257,14 +287,39 @@ export function AdaptThisRecipe({
               Suggested alternatives for this recipe
             </DrawerDescription>
           </DrawerHeader>
-          <div className="p-4 pb-8">
-            <p className="text-center text-sm text-muted-foreground">
-              No swap suggestions available for this recipe yet.
-            </p>
+          <div className="max-h-[60vh] space-y-4 overflow-y-auto p-4 pb-8">
+            {swaps.length === 0 ? (
+              <p className="text-center text-sm text-muted-foreground">
+                No swap suggestions available for this recipe yet.
+              </p>
+            ) : (
+              swaps.map((swap) => (
+                <div
+                  key={swap.originalIngredientId}
+                  className="rounded-lg border p-3"
+                >
+                  <p className="text-sm font-medium">{swap.originalName}</p>
+                  <ul className="mt-2 space-y-1.5">
+                    {swap.substitutes.map((sub) => (
+                      <li
+                        key={sub.ingredientId}
+                        className="text-sm text-muted-foreground"
+                      >
+                        <span className="font-medium text-foreground">
+                          {sub.ingredientName}
+                        </span>
+                        {" — "}
+                        {formatSwapQuantity(sub.quantity, sub.unit)}
+                        {sub.notes ? ` (${sub.notes})` : ""}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))
+            )}
           </div>
         </DrawerContent>
       </Drawer>
     </>
   );
 }
-

--- a/src/app/recipe/[slug]/_components/FullRecipePage.tsx
+++ b/src/app/recipe/[slug]/_components/FullRecipePage.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useState, useEffect, useCallback, type ReactNode } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type ReactNode,
+} from "react";
 import { useUser } from "@clerk/nextjs";
 import { AlertTriangle, Loader2, Check } from "lucide-react";
 import { type JSONContent } from "novel";
@@ -15,7 +21,10 @@ import {
 } from "@/components/ui/card";
 import { SignedIn, SignedOut } from "@clerk/nextjs";
 import { RecipeHeader } from "./RecipeHeader";
-import { AdaptThisRecipe } from "./AdaptThisRecipe";
+import {
+  AdaptThisRecipe,
+  type IngredientSwap,
+} from "./AdaptThisRecipe";
 import { StepsList, extractStepsFromContent } from "./StepsList";
 import { IngredientsPanel } from "./IngredientsPanel";
 import { CookModeOverlay } from "./CookModeOverlay";
@@ -24,7 +33,14 @@ import { MoreLikeThis } from "./MoreLikeThis";
 import { AdminWrapper } from "./AdminWrapper";
 import { checkIfFavorite, toggleFavorite } from "~/app/_actions/favorites";
 import { saveGeneralNote } from "~/app/_actions/userNotes";
-import { onPublishRecipe } from "./actions";
+import {
+  fetchRecipeView,
+  onPublishRecipe,
+} from "./actions";
+import type {
+  RecipeViewDTO,
+  RecipeViewIngredient,
+} from "./recipeViewTypes";
 
 interface FullRecipe {
   id: number;
@@ -79,10 +95,68 @@ interface FullRecipePageProps {
   adminEditSheet?: ReactNode;
   dangerZoneDialog?: ReactNode;
   hasV2Data?: boolean;
+  initialRecipeView?: RecipeViewDTO;
   userNotes?: UserNotes;
 }
 
 const DEFAULT_SERVINGS = 4;
+
+/**
+ * Formats a computed quantity for display in the ingredients panel.
+ * @param quantity - Numeric quantity from the recipe view
+ * @param unit - Unit string
+ * @returns Formatted quantity string
+ */
+function formatComputedQuantity(quantity: number, unit: string): string {
+  const formatted =
+    quantity % 1 === 0
+      ? quantity.toString()
+      : quantity.toFixed(2).replace(/\.?0+$/, "");
+  return unit ? `${formatted} ${unit}` : formatted;
+}
+
+/**
+ * Maps computed v2 ingredients into the IngredientsPanel shape.
+ * @param ingredients - Computed recipe view ingredients
+ * @param recipeId - Recipe ID for the panel item shape
+ * @returns Ingredients panel items
+ */
+function mapViewIngredients(
+  ingredients: RecipeViewIngredient[],
+  recipeId: number,
+): FullRecipe["ingredients"] {
+  return ingredients.map((ing) => ({
+    quantity: formatComputedQuantity(ing.quantity, ing.unit),
+    recipeId,
+    ingredientId: ing.ingredientId,
+    ingredient: {
+      id: ing.ingredientId,
+      name: ing.ingredientName,
+      description: ing.ingredientDescription,
+    },
+  }));
+}
+
+/**
+ * Builds swap suggestions from computed ingredients that have substitutions.
+ * @param ingredients - Computed recipe view ingredients
+ * @returns Ingredient swap groups for the adapt drawer
+ */
+function buildSwaps(ingredients: RecipeViewIngredient[]): IngredientSwap[] {
+  return ingredients
+    .filter((ing) => ing.substitutions.length > 0)
+    .map((ing) => ({
+      originalIngredientId: ing.ingredientId,
+      originalName: ing.ingredientName,
+      substitutes: ing.substitutions.map((sub) => ({
+        ingredientId: sub.ingredientId,
+        ingredientName: sub.ingredientName,
+        quantity: sub.quantity,
+        unit: sub.unit,
+        notes: sub.notes,
+      })),
+    }));
+}
 
 /**
  * Redesigned recipe page that feels like a cooking tool.
@@ -93,6 +167,9 @@ const DEFAULT_SERVINGS = 4;
  * @param relatedRecipes - Related recipes for "More like this" section
  * @param adminEditSheet - Server component for admin edit functionality
  * @param dangerZoneDialog - Server component for danger zone dialog
+ * @param hasV2Data - Whether this recipe has v2 versions
+ * @param initialRecipeView - SSR-loaded MEDIUM view for v2 recipes
+ * @param userNotes - Personalized notes for the signed-in user
  */
 export function FullRecipePageClient({
   recipe,
@@ -100,23 +177,71 @@ export function FullRecipePageClient({
   adminEditSheet,
   dangerZoneDialog,
   hasV2Data = false,
+  initialRecipeView,
   userNotes,
 }: FullRecipePageProps): JSX.Element {
   const { isSignedIn, isLoaded } = useUser();
   const [servings, setServings] = useState(DEFAULT_SERVINGS);
   const [difficulty, setDifficulty] = useState<DifficultyLevel>("MEDIUM");
+  const [recipeView, setRecipeView] = useState<RecipeViewDTO | undefined>(
+    initialRecipeView,
+  );
+  const [isViewLoading, setIsViewLoading] = useState(false);
+  const skipInitialFetch = useRef(
+    Boolean(
+      hasV2Data &&
+        initialRecipeView &&
+        initialRecipeView.difficulty === "MEDIUM" &&
+        initialRecipeView.servings === DEFAULT_SERVINGS,
+    ),
+  );
+
   const [isCookModeOpen, setIsCookModeOpen] = useState(false);
   const [isFavorite, setIsFavorite] = useState(false);
 
   const [generalNote, setGeneralNote] = useState(userNotes?.generalNote ?? "");
-  const [savedGeneralNote, setSavedGeneralNote] = useState(userNotes?.generalNote ?? "");
-  const [generalNoteSaveState, setGeneralNoteSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [savedGeneralNote, setSavedGeneralNote] = useState(
+    userNotes?.generalNote ?? "",
+  );
+  const [generalNoteSaveState, setGeneralNoteSaveState] = useState<
+    "idle" | "saving" | "saved" | "error"
+  >("idle");
   const [generalNoteError, setGeneralNoteError] = useState("");
 
   const tags = recipe.tags.map((t) => t.tag);
-  const steps = recipe.steps;
-  const stepStrings = extractStepsFromContent(steps);
-  const servingsMultiplier = servings / DEFAULT_SERVINGS;
+
+  useEffect(() => {
+    if (!hasV2Data) {
+      return;
+    }
+
+    if (skipInitialFetch.current) {
+      skipInitialFetch.current = false;
+      return;
+    }
+
+    let cancelled = false;
+    setIsViewLoading(true);
+
+    fetchRecipeView(recipe.id, difficulty, servings)
+      .then((view) => {
+        if (!cancelled) {
+          setRecipeView(view);
+        }
+      })
+      .catch((err: unknown) => {
+        console.error("Failed to fetch adapted recipe view:", err);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsViewLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasV2Data, recipe.id, difficulty, servings]);
 
   useEffect(() => {
     if (!isLoaded || !isSignedIn) {
@@ -158,6 +283,19 @@ export function FullRecipePageClient({
     }
   }, [recipe.id, generalNote]);
 
+  const useV2View = hasV2Data && recipeView !== undefined;
+  const displayIngredients = useV2View
+    ? mapViewIngredients(recipeView.ingredients, recipe.id)
+    : recipe.ingredients;
+  const stepInstructions = useV2View
+    ? recipeView.steps.map((step) => step.instruction)
+    : undefined;
+  const stepStrings = useV2View
+    ? recipeView.steps.map((step) => step.instruction)
+    : extractStepsFromContent(recipe.steps);
+  const servingsMultiplier = useV2View ? 1 : servings / DEFAULT_SERVINGS;
+  const swaps = useV2View ? buildSwaps(recipeView.ingredients) : [];
+
   return (
     <>
       {!recipe.published && (
@@ -184,13 +322,15 @@ export function FullRecipePageClient({
           difficulty={difficulty}
           onDifficultyChange={setDifficulty}
           hasV2Data={hasV2Data}
+          swaps={swaps}
         />
       </div>
 
       <div className="mb-6 lg:hidden">
         <IngredientsPanel
-          ingredients={recipe.ingredients}
+          ingredients={displayIngredients}
           servingsMultiplier={servingsMultiplier}
+          isLoading={isViewLoading}
           collapsible
           defaultOpen={false}
         />
@@ -199,11 +339,13 @@ export function FullRecipePageClient({
       <div className="flex gap-8">
         <main className="min-w-0 flex-1">
           <StepsList
-            steps={steps}
+            steps={useV2View ? null : recipe.steps}
+            stepInstructions={stepInstructions}
             onStartCookMode={handleStartCookMode}
             recipeId={recipe.id}
             isSignedIn={!!isSignedIn}
             stepNotes={userNotes?.stepNotes}
+            isLoading={isViewLoading}
           />
 
           <Card className="mt-8">
@@ -226,7 +368,10 @@ export function FullRecipePageClient({
                   <div className="flex items-center gap-2">
                     <Button
                       onClick={handleSaveGeneralNote}
-                      disabled={generalNoteSaveState === "saving" || generalNote === savedGeneralNote}
+                      disabled={
+                        generalNoteSaveState === "saving" ||
+                        generalNote === savedGeneralNote
+                      }
                     >
                       {generalNoteSaveState === "saving" ? (
                         <>
@@ -244,7 +389,9 @@ export function FullRecipePageClient({
                     </Button>
                   </div>
                   {generalNoteSaveState === "error" && (
-                    <p className="text-sm text-destructive">{generalNoteError}</p>
+                    <p className="text-sm text-destructive">
+                      {generalNoteError}
+                    </p>
                   )}
                 </div>
               </SignedIn>
@@ -275,11 +422,13 @@ export function FullRecipePageClient({
               difficulty={difficulty}
               onDifficultyChange={setDifficulty}
               hasV2Data={hasV2Data}
+              swaps={swaps}
             />
 
             <IngredientsPanel
-              ingredients={recipe.ingredients}
+              ingredients={displayIngredients}
               servingsMultiplier={servingsMultiplier}
+              isLoading={isViewLoading}
             />
           </div>
         </aside>
@@ -293,13 +442,17 @@ export function FullRecipePageClient({
         onStartCookMode={handleStartCookMode}
         servings={servings}
         onServingsChange={setServings}
+        difficulty={difficulty}
+        onDifficultyChange={setDifficulty}
+        hasV2Data={hasV2Data}
+        swaps={swaps}
       />
 
       <CookModeOverlay
         isOpen={isCookModeOpen}
         onClose={() => setIsCookModeOpen(false)}
         steps={stepStrings}
-        ingredients={recipe.ingredients}
+        ingredients={displayIngredients}
       />
     </>
   );

--- a/src/app/recipe/[slug]/_components/FullRecipePageServer.tsx
+++ b/src/app/recipe/[slug]/_components/FullRecipePageServer.tsx
@@ -12,10 +12,14 @@ import {
   getStepNotesForRecipe,
   getGeneralNoteForRecipe,
 } from "~/server/queries/userNotes";
+import { fetchRecipeView } from "./actions";
+import type { RecipeViewDTO } from "./recipeViewTypes";
 
 interface FullRecipePageServerProps {
   id: number;
 }
+
+const DEFAULT_SERVINGS = 4;
 
 /**
  * Server component that fetches recipe data and passes to client component.
@@ -28,18 +32,26 @@ export default async function FullRecipePageServer({
 }: FullRecipePageServerProps): Promise<JSX.Element> {
   const { userId } = auth();
 
-  // Fetch recipe, v2 data, related set, and user notes in parallel
   const [fullRecipe, hasV2, relatedRows, stepNotes, generalNote] =
     await Promise.all([
       getFullRecipeById(id),
       hasV2DataAsync(id),
       getRelatedRecipeSummariesExcluding(id),
-      getStepNotesForRecipe(id),
-      getGeneralNoteForRecipe(id),
+      userId ? getStepNotesForRecipe(id) : Promise.resolve({}),
+      userId ? getGeneralNoteForRecipe(id) : Promise.resolve(""),
     ]);
 
   if (!fullRecipe.published && !userId) {
     throw new Error("Recipe is unpublished.");
+  }
+
+  let initialRecipeView: RecipeViewDTO | undefined;
+  if (hasV2) {
+    try {
+      initialRecipeView = await fetchRecipeView(id, "MEDIUM", DEFAULT_SERVINGS);
+    } catch (err) {
+      console.error("Failed to load initial recipe view:", err);
+    }
   }
 
   const userNotes = userId ? { stepNotes, generalNote } : undefined;
@@ -97,6 +109,7 @@ export default async function FullRecipePageServer({
         />
       }
       hasV2Data={hasV2}
+      initialRecipeView={initialRecipeView}
       userNotes={userNotes}
     />
   );

--- a/src/app/recipe/[slug]/_components/IngredientsPanel.tsx
+++ b/src/app/recipe/[slug]/_components/IngredientsPanel.tsx
@@ -27,6 +27,7 @@ interface IngredientsPanelProps {
   servingsMultiplier?: number;
   collapsible?: boolean;
   defaultOpen?: boolean;
+  isLoading?: boolean;
 }
 
 /**
@@ -75,12 +76,14 @@ function formatScaledQuantity(quantity: string, multiplier: number): string {
  * @param servingsMultiplier - Multiplier for scaling quantities
  * @param collapsible - Whether to render as collapsible (for mobile)
  * @param defaultOpen - Default open state when collapsible
+ * @param isLoading - Whether adapted ingredients are loading
  */
 export function IngredientsPanel({
   ingredients,
   servingsMultiplier = 1,
   collapsible = false,
   defaultOpen = true,
+  isLoading = false,
 }: IngredientsPanelProps): JSX.Element {
   const [checkedItems, setCheckedItems] = useState<Record<number, boolean>>({});
   const [isOpen, setIsOpen] = useState(defaultOpen);
@@ -110,7 +113,9 @@ export function IngredientsPanel({
 
   const content = (
     <>
-      {ingredients.length === 0 ? (
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Updating ingredients...</p>
+      ) : ingredients.length === 0 ? (
         <p className="text-sm text-muted-foreground">Ingredients unavailable.</p>
       ) : (
         <ul className="space-y-3">

--- a/src/app/recipe/[slug]/_components/MobileStickyBar.tsx
+++ b/src/app/recipe/[slug]/_components/MobileStickyBar.tsx
@@ -10,8 +10,13 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@/components/ui/drawer";
-import { AdaptThisRecipe } from "./AdaptThisRecipe";
+import {
+  AdaptThisRecipe,
+  type IngredientSwap,
+} from "./AdaptThisRecipe";
 import { AuthGateModal } from "./AuthGateModal";
+
+type DifficultyLevel = "EASY" | "MEDIUM" | "HARD";
 
 interface MobileStickyBarProps {
   isFavorite: boolean;
@@ -19,17 +24,24 @@ interface MobileStickyBarProps {
   onStartCookMode: () => void;
   servings: number;
   onServingsChange: (servings: number) => void;
+  difficulty?: DifficultyLevel;
+  onDifficultyChange?: (difficulty: DifficultyLevel) => void;
+  hasV2Data?: boolean;
+  swaps?: IngredientSwap[];
 }
 
 /**
  * Mobile sticky bottom bar with quick action buttons.
  * Contains Cook Mode, Adapt drawer trigger, and Save button.
- * @param recipeId - The recipe ID
  * @param isFavorite - Whether the recipe is favorited
  * @param onToggleFavorite - Callback to toggle favorite
  * @param onStartCookMode - Callback to start cook mode
  * @param servings - Current servings
  * @param onServingsChange - Callback when servings change
+ * @param difficulty - Current difficulty level (v2)
+ * @param onDifficultyChange - Callback when difficulty changes (v2)
+ * @param hasV2Data - Whether this recipe has v2 difficulty variations
+ * @param swaps - Ingredient substitution suggestions
  */
 export function MobileStickyBar({
   isFavorite,
@@ -37,6 +49,10 @@ export function MobileStickyBar({
   onStartCookMode,
   servings,
   onServingsChange,
+  difficulty,
+  onDifficultyChange,
+  hasV2Data = false,
+  swaps = [],
 }: MobileStickyBarProps): JSX.Element {
   const { isSignedIn, isLoaded } = useUser();
   const [showAdaptDrawer, setShowAdaptDrawer] = useState(false);
@@ -89,6 +105,10 @@ export function MobileStickyBar({
             <AdaptThisRecipe
               servings={servings}
               onServingsChange={onServingsChange}
+              difficulty={difficulty}
+              onDifficultyChange={onDifficultyChange}
+              hasV2Data={hasV2Data}
+              swaps={swaps}
             />
           </div>
         </DrawerContent>
@@ -101,4 +121,3 @@ export function MobileStickyBar({
     </>
   );
 }
-

--- a/src/app/recipe/[slug]/_components/StepsList.tsx
+++ b/src/app/recipe/[slug]/_components/StepsList.tsx
@@ -14,11 +14,13 @@ import { cn } from "~/lib/utils";
 import { saveStepNote } from "~/app/_actions/userNotes";
 
 interface StepsListProps {
-  steps: JSONContent | null;
+  steps?: JSONContent | null;
+  stepInstructions?: string[];
   onStartCookMode: () => void;
   recipeId: number;
   isSignedIn: boolean;
   stepNotes?: Record<number, string>;
+  isLoading?: boolean;
 }
 
 /**
@@ -62,26 +64,31 @@ function extractStepsFromContent(content: JSONContent | null): string[] {
 
 /**
  * Steps list with decision support callouts.
- * Parses Novel editor JSON and renders scannable step cards.
+ * Accepts Novel editor JSON or precomputed instruction strings (v2 adapt view).
  * Supports per-step notes for logged-in users.
- * @param steps - Novel editor JSON content
+ * @param steps - Novel editor JSON content (v1)
+ * @param stepInstructions - Precomputed step strings (v2)
  * @param onStartCookMode - Callback to enter cook mode
  * @param recipeId - The recipe ID for saving notes
  * @param isSignedIn - Whether the user is signed in
  * @param stepNotes - Existing notes for each step
+ * @param isLoading - Whether adapted steps are loading
  */
 export function StepsList({
-  steps,
+  steps = null,
+  stepInstructions,
   onStartCookMode,
   recipeId,
   isSignedIn,
   stepNotes = {},
+  isLoading = false,
 }: StepsListProps): JSX.Element {
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
   const [showCommonFixes, setShowCommonFixes] = useState(false);
   const [showKeyCues, setShowKeyCues] = useState(false);
 
-  const stepStrings = extractStepsFromContent(steps);
+  const stepStrings =
+    stepInstructions ?? extractStepsFromContent(steps);
 
   const toggleStepCompletion = (index: number): void => {
     setCompletedSteps((prev) => {
@@ -109,7 +116,11 @@ export function StepsList({
         <Button onClick={onStartCookMode}>Start Cook Mode</Button>
       </div>
 
-      {stepStrings.length === 0 ? (
+      {isLoading ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-muted-foreground">Updating steps...</p>
+        </div>
+      ) : stepStrings.length === 0 ? (
         <div className="rounded-lg border border-dashed p-8 text-center">
           <p className="text-muted-foreground">
             No steps available for this recipe.

--- a/src/app/recipe/[slug]/_components/actions.tsx
+++ b/src/app/recipe/[slug]/_components/actions.tsx
@@ -11,8 +11,57 @@ import {
   removeIngredientFromRecipe,
   updateRecipeHeroImage,
   getAllImages,
+  getRecipeViewAsync,
 } from "~/server/queries";
+import type { Difficulty } from "~/server/db/schemas";
 import type { AssignTagsFormSchema } from "./AssignTagsForm";
+import type { RecipeViewDTO } from "./recipeViewTypes";
+
+/**
+ * Fetches a computed recipe view for the given difficulty and servings.
+ * Used by the cook-facing adapt controls on the recipe page.
+ * @param recipeId - Recipe ID
+ * @param difficulty - Target difficulty level
+ * @param servings - Desired servings count
+ * @returns Serializable recipe view DTO
+ */
+export async function fetchRecipeView(
+  recipeId: number,
+  difficulty: Difficulty,
+  servings: number,
+): Promise<RecipeViewDTO> {
+  const view = await getRecipeViewAsync(recipeId, difficulty, servings);
+
+  return {
+    recipeId: view.recipeId,
+    difficulty: view.difficulty,
+    servings: view.servings,
+    ingredients: view.ingredients.map((ing) => ({
+      id: ing.id,
+      ingredientId: ing.ingredientId,
+      ingredientName: ing.ingredientName,
+      ingredientDescription: ing.ingredientDescription,
+      quantity: ing.quantity,
+      unit: ing.unit,
+      notes: ing.notes,
+      isOptional: ing.isOptional,
+      substitutions: ing.substitutions.map((sub) => ({
+        ingredientId: sub.ingredientId,
+        ingredientName: sub.ingredientName,
+        quantity: sub.quantity,
+        unit: sub.unit,
+        notes: sub.notes,
+      })),
+    })),
+    steps: view.steps.map((step) => ({
+      id: step.id,
+      stepOrder: step.stepOrder,
+      instruction: step.instruction,
+      mediaUrl: step.mediaUrl,
+      timerSeconds: step.timerSeconds,
+    })),
+  };
+}
 
 export async function onTagSubmit(
   recipeId: number,

--- a/src/app/recipe/[slug]/_components/recipeViewTypes.ts
+++ b/src/app/recipe/[slug]/_components/recipeViewTypes.ts
@@ -1,0 +1,37 @@
+import type { Difficulty } from "~/server/db/schemas";
+
+export type RecipeViewSubstitution = {
+  ingredientId: number;
+  ingredientName: string;
+  quantity: number;
+  unit: string;
+  notes: string | null;
+};
+
+export type RecipeViewIngredient = {
+  id: number;
+  ingredientId: number;
+  ingredientName: string;
+  ingredientDescription: string | null;
+  quantity: number;
+  unit: string;
+  notes: string | null;
+  isOptional: boolean;
+  substitutions: RecipeViewSubstitution[];
+};
+
+export type RecipeViewStep = {
+  id: number;
+  stepOrder: number;
+  instruction: string;
+  mediaUrl: string | null;
+  timerSeconds: number | null;
+};
+
+export type RecipeViewDTO = {
+  recipeId: number;
+  difficulty: Difficulty;
+  servings: number;
+  ingredients: RecipeViewIngredient[];
+  steps: RecipeViewStep[];
+};


### PR DESCRIPTION
## Summary
- Wire recipe-page Adapt controls to `getRecipeViewAsync` so Easy/Medium/Hard and servings update ingredients and steps for v2 recipes
- SSR-load the initial MEDIUM view so wizard/v2 recipes show content on first paint
- Populate the ingredient swaps drawer from computed substitutions

## Test plan
- [ ] Open a v2 recipe (e.g. cashew-miso-pasta) signed out and signed in — ingredients/steps render
- [ ] Change Easy / Medium / Hard — ingredients and steps update
- [ ] Change servings — quantities update (server-side scaling)
- [ ] Open See swaps — substitutions appear when present; empty state otherwise
- [ ] Start Cook Mode — uses the currently adapted step list
- [ ] Open a v1-only recipe — client servings multiplier still works; no regressions


Made with [Cursor](https://cursor.com)