### PR TITLE
feat: overhaul design system with Herb & Chili editorial look

### DIFF
--- a/components.json
+++ b/components.json
@@ -6,8 +6,8 @@
   "tailwind": {
     "config": "tailwind.config.ts",
     "css": "src/styles/globals.css",
-    "baseColor": "slate",
-    "cssVariables": false,
+    "baseColor": "neutral",
+    "cssVariables": true,
     "prefix": ""
   },
   "aliases": {

--- a/src/app/_components/AdaptiveRecipePreview.tsx
+++ b/src/app/_components/AdaptiveRecipePreview.tsx
@@ -52,8 +52,8 @@ export function AdaptiveRecipePreview({
   return (
     <section id="recipe-preview" className="scroll-mt-8">
       <div className="grid gap-8 lg:grid-cols-2 lg:gap-12">
-        <div className="overflow-hidden rounded-2xl border border-neutral-200/60 bg-white shadow-sm transition-all dark:border-neutral-800 dark:bg-neutral-900">
-          <div className="relative aspect-[4/3] overflow-hidden bg-neutral-100 dark:bg-neutral-800">
+        <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-soft">
+          <div className="relative aspect-[4/3] overflow-hidden bg-muted">
             {recipe.heroImage?.url ? (
               <Image
                 src={recipe.heroImage.url}
@@ -64,22 +64,23 @@ export function AdaptiveRecipePreview({
               />
             ) : (
               <div className="flex h-full items-center justify-center">
-                <Utensils className="h-16 w-16 text-neutral-300 dark:text-neutral-600" />
+                <Utensils className="h-16 w-16 text-muted-foreground/40" />
               </div>
             )}
           </div>
           <div className="p-6">
-            <h3 className="mb-2 text-xl font-semibold tracking-tight text-neutral-900 dark:text-white">
+            <h3 className="mb-2 font-display text-xl font-semibold tracking-tight text-foreground">
               {recipe.name}
             </h3>
-            <p className="mb-4 line-clamp-2 text-[14px] leading-relaxed text-neutral-500 dark:text-neutral-400">
+            <p className="mb-4 line-clamp-2 text-[14px] leading-relaxed text-muted-foreground">
               {recipe.description}
             </p>
-            <div className="flex flex-wrap items-center gap-4 text-[13px] text-neutral-500 dark:text-neutral-400">
+            <div className="flex flex-wrap items-center gap-4 text-[13px] text-muted-foreground">
               {(recipe.prepTime ?? recipe.cookTime) && (
                 <span className="flex items-center gap-1.5">
                   <Clock className="h-4 w-4" />
-                  Prep: {recipe.prepTime ?? 15} min | Cook: {recipe.cookTime ?? 25} min
+                  Prep: {recipe.prepTime ?? 15} min | Cook:{" "}
+                  {recipe.cookTime ?? 25} min
                 </span>
               )}
               {!recipe.prepTime && !recipe.cookTime && (
@@ -88,13 +89,13 @@ export function AdaptiveRecipePreview({
                   Prep: 15 min | Cook: 25 min
                 </span>
               )}
-              <span className="rounded-full bg-neutral-100 px-2.5 py-0.5 text-[12px] font-medium dark:bg-neutral-800">
+              <span className="rounded-md bg-herb-muted px-2.5 py-0.5 text-[12px] font-medium text-herb">
                 {recipe.difficulty ?? "Medium"}
               </span>
             </div>
             <Link
               href={`/recipe/${recipe.slug}`}
-              className="mt-4 inline-flex items-center gap-1.5 text-[14px] font-medium text-neutral-900 transition-colors hover:text-neutral-600 dark:text-white dark:hover:text-neutral-300"
+              className="mt-4 inline-flex items-center gap-1.5 text-[14px] font-medium text-foreground transition-colors hover:text-accent"
             >
               View full recipe
               <ArrowRight className="h-3.5 w-3.5" />
@@ -103,12 +104,12 @@ export function AdaptiveRecipePreview({
         </div>
 
         <div className="flex flex-col">
-          <div className="flex-1 rounded-2xl border border-neutral-200/60 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex-1 rounded-2xl border border-border bg-card p-6 shadow-soft">
             <div className="mb-6 flex items-center justify-between">
-              <h4 className="text-lg font-semibold tracking-tight text-neutral-900 dark:text-white">
+              <h4 className="font-display text-lg font-semibold tracking-tight text-foreground">
                 Adapt This Recipe
               </h4>
-              <span className="flex items-center gap-1.5 rounded-full bg-neutral-100 px-3 py-1 text-[12px] font-medium text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
+              <span className="flex items-center gap-1.5 rounded-md bg-muted px-3 py-1 text-[12px] font-medium text-muted-foreground">
                 <Lock className="h-3 w-3" />
                 Preview
               </span>
@@ -117,9 +118,9 @@ export function AdaptiveRecipePreview({
             <div className="space-y-6">
               <div className="relative">
                 <div className="absolute -right-1 -top-1 z-10">
-                  <Lock className="h-3.5 w-3.5 text-neutral-400 dark:text-neutral-500" />
+                  <Lock className="h-3.5 w-3.5 text-muted-foreground" />
                 </div>
-                <label className="mb-2.5 flex items-center gap-2 text-[13px] font-medium text-neutral-600 dark:text-neutral-400">
+                <label className="mb-2.5 flex items-center gap-2 text-[13px] font-medium text-muted-foreground">
                   <Clock className="h-4 w-4" />
                   Total Time
                 </label>
@@ -130,8 +131,8 @@ export function AdaptiveRecipePreview({
                       disabled
                       className={`flex-1 rounded-lg border px-3 py-2.5 text-[13px] font-medium transition-all ${
                         option.isSelected
-                          ? "border-neutral-900 bg-neutral-900 text-white dark:border-white dark:bg-white dark:text-neutral-900"
-                          : "border-neutral-200 bg-white text-neutral-600 opacity-60 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border bg-card text-muted-foreground opacity-60"
                       }`}
                     >
                       {option.label}
@@ -142,9 +143,9 @@ export function AdaptiveRecipePreview({
 
               <div className="relative">
                 <div className="absolute -right-1 -top-1 z-10">
-                  <Lock className="h-3.5 w-3.5 text-neutral-400 dark:text-neutral-500" />
+                  <Lock className="h-3.5 w-3.5 text-muted-foreground" />
                 </div>
-                <label className="mb-2.5 flex items-center gap-2 text-[13px] font-medium text-neutral-600 dark:text-neutral-400">
+                <label className="mb-2.5 flex items-center gap-2 text-[13px] font-medium text-muted-foreground">
                   <Users className="h-4 w-4" />
                   Servings
                 </label>
@@ -155,8 +156,8 @@ export function AdaptiveRecipePreview({
                       disabled
                       className={`flex-1 rounded-lg border px-3 py-2.5 text-[13px] font-medium transition-all ${
                         option.isSelected
-                          ? "border-neutral-900 bg-neutral-900 text-white dark:border-white dark:bg-white dark:text-neutral-900"
-                          : "border-neutral-200 bg-white text-neutral-600 opacity-60 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border bg-card text-muted-foreground opacity-60"
                       }`}
                     >
                       {option.value}
@@ -167,37 +168,37 @@ export function AdaptiveRecipePreview({
 
               <div className="relative">
                 <div className="absolute -right-1 -top-1 z-10">
-                  <Lock className="h-3.5 w-3.5 text-neutral-400 dark:text-neutral-500" />
+                  <Lock className="h-3.5 w-3.5 text-muted-foreground" />
                 </div>
-                <label className="mb-2.5 flex items-center gap-2 text-[13px] font-medium text-neutral-600 dark:text-neutral-400">
+                <label className="mb-2.5 flex items-center gap-2 text-[13px] font-medium text-muted-foreground">
                   <Leaf className="h-4 w-4" />
                   Ingredient Swaps
                 </label>
-                <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-3 text-[13px] text-neutral-500 opacity-75 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400">
+                <div className="rounded-lg border border-border bg-muted px-4 py-3 text-[13px] text-muted-foreground opacity-75">
                   3 alternatives available
                 </div>
               </div>
 
               <div className="relative">
                 <div className="absolute -right-1 -top-1 z-10">
-                  <Lock className="h-3.5 w-3.5 text-neutral-400 dark:text-neutral-500" />
+                  <Lock className="h-3.5 w-3.5 text-muted-foreground" />
                 </div>
-                <label className="mb-2.5 flex items-center gap-2 text-[13px] font-medium text-neutral-600 dark:text-neutral-400">
+                <label className="mb-2.5 flex items-center gap-2 text-[13px] font-medium text-muted-foreground">
                   <Gauge className="h-4 w-4" />
                   Difficulty
                 </label>
-                <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-3 text-[13px] text-neutral-500 opacity-75 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400">
+                <div className="rounded-lg border border-border bg-muted px-4 py-3 text-[13px] text-muted-foreground opacity-75">
                   Beginner-friendly
                 </div>
               </div>
             </div>
 
-            <div className="mt-8 rounded-xl border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-700 dark:bg-neutral-800">
-              <p className="mb-3 text-center text-[14px] text-neutral-600 dark:text-neutral-400">
+            <div className="mt-8 rounded-xl border border-border bg-muted/60 p-4">
+              <p className="mb-3 text-center text-[14px] text-muted-foreground">
                 Create a free account to adapt recipes instantly.
               </p>
               <SignInButton mode="modal">
-                <Button className="w-full rounded-xl bg-neutral-900 text-[14px] font-medium shadow-sm transition-all hover:bg-neutral-800 hover:shadow-md dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-100">
+                <Button className="w-full text-[14px]">
                   Unlock Adaptations
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Button>
@@ -209,4 +210,3 @@ export function AdaptiveRecipePreview({
     </section>
   );
 }
-

--- a/src/app/_components/CategoryPills.tsx
+++ b/src/app/_components/CategoryPills.tsx
@@ -42,6 +42,12 @@ export function CategoryPills({
     }
   };
 
+  const pillBase =
+    "flex shrink-0 items-center gap-1.5 rounded-md px-4 py-2 text-[13px] font-medium transition-all duration-150";
+  const pillActive = "bg-primary text-primary-foreground shadow-soft";
+  const pillIdle =
+    "bg-muted text-muted-foreground hover:bg-secondary hover:text-foreground";
+
   return (
     <div className="relative -mx-1">
       <div className="scrollbar-hide flex gap-2 overflow-x-auto px-1 pb-1">
@@ -49,10 +55,8 @@ export function CategoryPills({
           <button
             onClick={() => onSelect(null)}
             className={cn(
-              "flex shrink-0 items-center gap-1.5 rounded-full px-4 py-2 text-[13px] font-medium transition-all duration-150",
-              selectedTagId === null
-                ? "bg-neutral-900 text-white shadow-sm dark:bg-white dark:text-neutral-900"
-                : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200 hover:text-neutral-900 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:hover:text-white",
+              pillBase,
+              selectedTagId === null ? pillActive : pillIdle,
             )}
           >
             All Recipes
@@ -63,10 +67,8 @@ export function CategoryPills({
             key={tag.id}
             onClick={() => onSelect(tag.id)}
             className={cn(
-              "flex shrink-0 items-center gap-1.5 rounded-full px-4 py-2 text-[13px] font-medium transition-all duration-150",
-              selectedTagId === tag.id
-                ? "bg-neutral-900 text-white shadow-sm dark:bg-white dark:text-neutral-900"
-                : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200 hover:text-neutral-900 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:hover:text-white",
+              pillBase,
+              selectedTagId === tag.id ? pillActive : pillIdle,
             )}
           >
             {getTagIcon(tag.tagType)}
@@ -87,7 +89,7 @@ export function CategoryPillsSkeleton(): JSX.Element {
       {Array.from({ length: 6 }, (_, i) => (
         <div
           key={i}
-          className="h-9 w-24 shrink-0 animate-pulse rounded-full bg-neutral-100 dark:bg-neutral-800"
+          className="h-9 w-24 shrink-0 animate-pulse rounded-md bg-muted"
         />
       ))}
     </div>

--- a/src/app/_components/CollectionCard.tsx
+++ b/src/app/_components/CollectionCard.tsx
@@ -21,9 +21,9 @@ export function CollectionCard({
   return (
     <Link
       href={`/collections/${collection.id}`}
-      className="group block h-full overflow-hidden rounded-2xl border border-neutral-200/60 bg-white transition-all duration-200 hover:border-neutral-300 hover:shadow-lg hover:shadow-neutral-200/50 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700 dark:hover:shadow-neutral-950/50"
+      className="group block h-full overflow-hidden rounded-2xl border border-border bg-card transition-all duration-200 hover:border-foreground/15 hover:shadow-lift"
     >
-      <div className="relative aspect-[4/3] overflow-hidden bg-neutral-100 dark:bg-neutral-800">
+      <div className="relative aspect-[4/3] overflow-hidden bg-muted">
         {firstRecipe?.heroImage?.url ? (
           <Image
             src={firstRecipe.heroImage.url}
@@ -34,24 +34,23 @@ export function CollectionCard({
           />
         ) : (
           <div className="flex h-full items-center justify-center">
-            <Soup size={48} className="text-neutral-300 dark:text-neutral-600" />
+            <Soup size={48} className="text-muted-foreground/40" />
           </div>
         )}
       </div>
       <div className="p-5">
-        <h3 className="mb-2 text-[17px] font-semibold leading-snug tracking-tight text-neutral-900 transition-colors group-hover:text-neutral-700 dark:text-white dark:group-hover:text-neutral-200">
+        <h3 className="mb-2 font-display text-[17px] font-semibold leading-snug tracking-tight text-foreground transition-colors group-hover:text-accent">
           {collection.title}
         </h3>
         {collection.description && (
-          <p className="mb-2 line-clamp-2 text-[14px] leading-relaxed text-neutral-500 dark:text-neutral-400">
+          <p className="mb-2 line-clamp-2 text-[14px] leading-relaxed text-muted-foreground">
             {collection.description}
           </p>
         )}
-        <p className="text-[13px] text-neutral-400 dark:text-neutral-500">
+        <p className="text-[13px] text-muted-foreground">
           {recipeCount} {recipeCount === 1 ? "recipe" : "recipes"}
         </p>
       </div>
     </Link>
   );
 }
-

--- a/src/app/_components/CollectionsSection.tsx
+++ b/src/app/_components/CollectionsSection.tsx
@@ -20,13 +20,13 @@ export function CollectionsSection({
     return (
       <section id="collections" className="py-4">
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold tracking-tight text-neutral-900 dark:text-white">
+          <h2 className="text-lg font-semibold tracking-tight text-foreground dark:text-foreground">
             Your Collections
           </h2>
           <CreateCollectionDialog />
         </div>
-        <div className="flex items-center justify-center rounded-2xl border border-dashed border-neutral-200 bg-neutral-50/50 py-8 dark:border-neutral-800 dark:bg-neutral-900/50">
-          <p className="text-[15px] text-neutral-500 dark:text-neutral-400">
+        <div className="flex items-center justify-center rounded-2xl border border-dashed border-border bg-muted/50 py-8 dark:border-border dark:bg-card/50">
+          <p className="text-[15px] text-muted-foreground dark:text-muted-foreground">
             No collections yet — create one to organize your recipes
           </p>
         </div>
@@ -37,14 +37,14 @@ export function CollectionsSection({
   return (
     <section id="collections" className="py-4">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold tracking-tight text-neutral-900 dark:text-white">
+        <h2 className="text-lg font-semibold tracking-tight text-foreground dark:text-foreground">
           Your Collections
         </h2>
         <div className="flex items-center gap-2">
           <CreateCollectionDialog buttonText="Create" />
           <Link
             href="/collections"
-            className="flex items-center gap-1 text-[14px] font-medium text-neutral-600 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white"
+            className="flex items-center gap-1 text-[14px] font-medium text-muted-foreground transition-colors hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground"
           >
             See all
             <ArrowRight className="h-4 w-4" />
@@ -70,12 +70,12 @@ export function CollectionsSection({
  */
 export function CollectionCardSkeleton(): JSX.Element {
   return (
-    <div className="h-full overflow-hidden rounded-2xl border border-neutral-200/60 bg-white dark:border-neutral-800 dark:bg-neutral-900">
-      <div className="relative aspect-[4/3] animate-pulse bg-neutral-100 dark:bg-neutral-800" />
+    <div className="h-full overflow-hidden rounded-2xl border border-border bg-card dark:border-border dark:bg-card">
+      <div className="relative aspect-[4/3] animate-pulse bg-muted dark:bg-muted" />
       <div className="p-5">
-        <div className="mb-2 h-5 w-3/4 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
-        <div className="mb-2 h-4 w-full animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
-        <div className="h-3 w-1/2 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+        <div className="mb-2 h-5 w-3/4 animate-pulse rounded bg-muted dark:bg-muted" />
+        <div className="mb-2 h-4 w-full animate-pulse rounded bg-muted dark:bg-muted" />
+        <div className="h-3 w-1/2 animate-pulse rounded bg-muted dark:bg-muted" />
       </div>
     </div>
   );

--- a/src/app/_components/CommandSearch.tsx
+++ b/src/app/_components/CommandSearch.tsx
@@ -46,7 +46,7 @@ export function CommandSearch() {
   return (
     <>
       <button
-        className="relative inline-flex h-8 w-full max-w-[140px] items-center justify-start whitespace-nowrap rounded-[0.5rem] border border-input bg-muted/50 px-3 py-2 text-sm font-normal text-muted-foreground shadow-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 sm:max-w-xs sm:pr-12 md:w-40 lg:w-64"
+        className="relative inline-flex h-8 w-full max-w-[140px] items-center justify-start whitespace-nowrap rounded-md border border-border bg-card px-3 py-2 text-sm font-normal text-muted-foreground shadow-none transition-colors hover:border-foreground/20 hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 sm:max-w-xs sm:pr-12 md:w-40 lg:w-64"
         onClick={handleOpen}
       >
         <span className="hidden lg:inline-flex">Search recipes...</span>

--- a/src/app/_components/CompactHero.tsx
+++ b/src/app/_components/CompactHero.tsx
@@ -30,43 +30,39 @@ export function CompactHero({ featuredRecipe }: HeroProps): JSX.Element {
   };
 
   return (
-    <section className="relative w-full overflow-hidden bg-neutral-50 dark:bg-neutral-900">
-      <div 
-        className="absolute inset-0 opacity-[0.4] dark:opacity-[0.15]"
-        style={{
-          backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23000000' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        }}
-      />
-      
-      <div className="absolute left-0 top-0 h-[600px] w-[600px] -translate-x-1/3 -translate-y-1/3 rounded-full bg-gradient-to-br from-amber-200/20 to-orange-100/10 blur-3xl dark:from-amber-500/10 dark:to-orange-500/5" />
-      <div className="absolute bottom-0 right-0 h-[500px] w-[500px] translate-x-1/4 translate-y-1/4 rounded-full bg-gradient-to-tl from-orange-200/15 to-amber-100/10 blur-3xl dark:from-orange-500/10 dark:to-amber-500/5" />
+    <section className="relative w-full overflow-hidden border-b border-border/60 bg-background">
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-gradient-to-l from-herb-muted/40 to-transparent" />
 
       <div className="container relative z-10 mx-auto px-4 py-16 md:py-24">
         <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
-          <div className="max-w-xl">
-            <h1 className="mb-6 text-balance text-4xl font-semibold tracking-tight text-neutral-900 dark:text-white sm:text-5xl lg:text-[3.25rem]">
+          <div className="animate-rise max-w-xl">
+            <p className="mb-4 font-display text-2xl tracking-tight text-foreground md:text-3xl">
+              Hyper Recipes
+            </p>
+            <h1 className="mb-6 text-balance font-display text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-[3.25rem]">
               Recipes that adapt to how you cook.
             </h1>
-            <p className="mb-8 text-lg leading-relaxed text-neutral-600 dark:text-neutral-400">
-              Hyper Recipes aren&apos;t static blog posts. Each recipe adjusts to your time, ingredients, and skill level—so you can cook with confidence, not guesswork.
+            <p className="mb-8 text-lg leading-relaxed text-muted-foreground">
+              Not static blog posts. Each recipe adjusts to your time,
+              ingredients, and skill—so you cook with confidence, not guesswork.
             </p>
-            
+
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-              <Button 
-                size="lg" 
+              <Button
+                size="lg"
                 onClick={scrollToPreview}
-                className="h-12 rounded-xl bg-neutral-900 px-8 text-[15px] font-medium shadow-lg shadow-neutral-900/10 transition-all hover:bg-neutral-800 hover:shadow-xl hover:shadow-neutral-900/15 dark:bg-white dark:text-neutral-900 dark:shadow-white/5 dark:hover:bg-neutral-100"
+                className="h-12 px-8 text-[15px]"
               >
                 Try a smart recipe
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Button>
-              
+
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="inline-block">
                       <SignInButton mode="modal">
-                        <button className="group flex items-center gap-1 text-[15px] font-medium text-neutral-500 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white">
+                        <button className="group flex items-center gap-1 text-[15px] font-medium text-muted-foreground transition-colors hover:text-foreground">
                           Or unlock smart recipes for free
                           <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
                         </button>
@@ -82,49 +78,51 @@ export function CompactHero({ featuredRecipe }: HeroProps): JSX.Element {
           </div>
 
           {featuredRecipe && (
-            <div className="relative">
-              <div className="overflow-hidden rounded-2xl border border-neutral-200/60 bg-white shadow-xl shadow-neutral-200/40 transition-all dark:border-neutral-800 dark:bg-neutral-900 dark:shadow-neutral-950/40">
-                <div className="relative aspect-[4/3] overflow-hidden bg-neutral-100 dark:bg-neutral-800">
+            <div className="animate-rise relative" style={{ animationDelay: "120ms" }}>
+              <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-lift transition-shadow hover:shadow-lift">
+                <div className="relative aspect-[4/3] overflow-hidden bg-muted">
                   {featuredRecipe.heroImage?.url ? (
                     <Image
                       src={featuredRecipe.heroImage.url}
                       alt={featuredRecipe.name}
                       fill
-                      className="object-cover"
+                      className="object-cover transition-transform duration-500 hover:scale-[1.02]"
                       priority
                     />
                   ) : (
                     <div className="flex h-full items-center justify-center">
-                      <Utensils className="h-16 w-16 text-neutral-300 dark:text-neutral-600" />
+                      <Utensils className="h-16 w-16 text-muted-foreground/40" />
                     </div>
                   )}
                 </div>
                 <div className="p-6">
-                  <p className="mb-2 text-[12px] font-semibold uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+                  <p className="mb-2 text-[12px] font-semibold uppercase tracking-widest text-accent">
                     Featured Recipe
                   </p>
-                  <h3 className="mb-2 text-xl font-semibold tracking-tight text-neutral-900 dark:text-white">
+                  <h3 className="mb-2 font-display text-xl font-semibold tracking-tight text-foreground">
                     {featuredRecipe.name}
                   </h3>
-                  <p className="mb-4 line-clamp-2 text-[14px] leading-relaxed text-neutral-500 dark:text-neutral-400">
+                  <p className="mb-4 line-clamp-2 text-[14px] leading-relaxed text-muted-foreground">
                     {featuredRecipe.description}
                   </p>
-                  <div className="flex items-center gap-4 text-[13px] text-neutral-500 dark:text-neutral-400">
+                  <div className="flex items-center gap-4 text-[13px] text-muted-foreground">
                     {(featuredRecipe.prepTime ?? featuredRecipe.cookTime) && (
                       <span className="flex items-center gap-1.5">
                         <Clock className="h-4 w-4" />
-                        {(featuredRecipe.prepTime ?? 0) + (featuredRecipe.cookTime ?? 0)} min
+                        {(featuredRecipe.prepTime ?? 0) +
+                          (featuredRecipe.cookTime ?? 0)}{" "}
+                        min
                       </span>
                     )}
                     {featuredRecipe.difficulty && (
-                      <span className="rounded-full bg-neutral-100 px-2.5 py-0.5 text-[12px] font-medium dark:bg-neutral-800">
+                      <span className="rounded-md bg-herb-muted px-2.5 py-0.5 text-[12px] font-medium text-herb">
                         {featuredRecipe.difficulty}
                       </span>
                     )}
                   </div>
                   <Link
                     href={`/recipe/${featuredRecipe.slug}`}
-                    className="mt-4 inline-flex items-center gap-1.5 text-[14px] font-medium text-neutral-900 transition-colors hover:text-neutral-600 dark:text-white dark:hover:text-neutral-300"
+                    className="mt-4 inline-flex items-center gap-1.5 text-[14px] font-medium text-foreground transition-colors hover:text-accent"
                   >
                     View recipe
                     <ArrowRight className="h-3.5 w-3.5" />

--- a/src/app/_components/FavoritesSection.tsx
+++ b/src/app/_components/FavoritesSection.tsx
@@ -19,8 +19,8 @@ export function FavoritesSection({
   if (!favorites || favorites.length === 0) {
     return (
       <section id="favorites" className="py-4">
-        <div className="flex items-center justify-center rounded-2xl border border-dashed border-neutral-200 bg-neutral-50/50 py-8 dark:border-neutral-800 dark:bg-neutral-900/50">
-          <p className="text-[15px] text-neutral-500 dark:text-neutral-400">
+        <div className="flex items-center justify-center rounded-2xl border border-dashed border-border bg-muted/50 py-8 dark:border-border dark:bg-card/50">
+          <p className="text-[15px] text-muted-foreground dark:text-muted-foreground">
             No favorites yet — browse below to find recipes you love
           </p>
         </div>
@@ -31,12 +31,12 @@ export function FavoritesSection({
   return (
     <section id="favorites" className="py-4">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold tracking-tight text-neutral-900 dark:text-white">
+        <h2 className="text-lg font-semibold tracking-tight text-foreground dark:text-foreground">
           Your Favorites
         </h2>
         <Link
           href="/favorites"
-          className="flex items-center gap-1 text-[14px] font-medium text-neutral-600 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white"
+          className="flex items-center gap-1 text-[14px] font-medium text-muted-foreground transition-colors hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground"
         >
           See all
           <ArrowRight className="h-4 w-4" />
@@ -63,8 +63,8 @@ export function FavoritesSectionSkeleton(): JSX.Element {
   return (
     <section className="py-4">
       <div className="mb-4 flex items-center justify-between">
-        <div className="h-6 w-32 animate-pulse rounded-md bg-neutral-100 dark:bg-neutral-800" />
-        <div className="h-5 w-16 animate-pulse rounded-md bg-neutral-100 dark:bg-neutral-800" />
+        <div className="h-6 w-32 animate-pulse rounded-md bg-muted dark:bg-muted" />
+        <div className="h-5 w-16 animate-pulse rounded-md bg-muted dark:bg-muted" />
       </div>
       <div className="flex gap-4 overflow-x-auto pb-2">
         {Array.from({ length: 4 }, (_, i) => (

--- a/src/app/_components/FeaturedRecipeSpotlight.tsx
+++ b/src/app/_components/FeaturedRecipeSpotlight.tsx
@@ -14,9 +14,9 @@ type FeaturedRecipeSpotlightProps = {
  */
 export function FeaturedRecipeSpotlight({ recipe }: FeaturedRecipeSpotlightProps): JSX.Element {
   return (
-    <section className="group overflow-hidden rounded-2xl border border-neutral-200/60 bg-white transition-all duration-200 hover:border-neutral-300 hover:shadow-lg hover:shadow-neutral-200/50 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700 dark:hover:shadow-neutral-950/50">
+    <section className="group overflow-hidden rounded-2xl border border-border bg-card transition-all duration-200 hover:border-foreground/15 hover:shadow-lg hover:shadow-lift dark:border-border dark:bg-card dark:hover:border-border dark:hover:shadow-lift">
       <div className="grid grid-cols-1 md:grid-cols-2">
-        <div className="relative aspect-[4/3] overflow-hidden bg-neutral-100 dark:bg-neutral-800 md:aspect-auto md:min-h-[320px]">
+        <div className="relative aspect-[4/3] overflow-hidden bg-muted dark:bg-muted md:aspect-auto md:min-h-[320px]">
           {recipe.heroImage?.url ? (
             <Image
               src={recipe.heroImage.url}
@@ -27,23 +27,23 @@ export function FeaturedRecipeSpotlight({ recipe }: FeaturedRecipeSpotlightProps
             />
           ) : (
             <div className="flex h-full min-h-[280px] w-full items-center justify-center">
-              <Utensils className="h-16 w-16 text-neutral-300 dark:text-neutral-600" />
+              <Utensils className="h-16 w-16 text-muted-foreground/40 dark:text-muted-foreground" />
             </div>
           )}
         </div>
         <div className="flex flex-col justify-center p-8 md:p-10">
-          <p className="mb-3 text-[12px] font-semibold uppercase tracking-widest text-neutral-400 dark:text-neutral-500">
+          <p className="mb-3 text-[12px] font-semibold uppercase tracking-widest text-muted-foreground dark:text-muted-foreground">
             Featured Recipe
           </p>
-          <h3 className="mb-3 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-white md:text-3xl">
+          <h3 className="mb-3 text-2xl font-semibold tracking-tight text-foreground dark:text-foreground md:text-3xl">
             {recipe.name}
           </h3>
-          <p className="mb-8 line-clamp-3 text-[15px] leading-relaxed text-neutral-500 dark:text-neutral-400">
+          <p className="mb-8 line-clamp-3 text-[15px] leading-relaxed text-muted-foreground dark:text-muted-foreground">
             {recipe.description}
           </p>
           <Button 
             asChild 
-            className="w-fit rounded-xl bg-neutral-900 px-6 text-[14px] font-medium shadow-sm transition-all hover:bg-neutral-800 hover:shadow-md dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-100"
+            className="w-fit rounded-xl bg-primary px-6 text-[14px] font-medium shadow-sm transition-all hover:bg-muted hover:shadow-md dark:bg-card dark:text-foreground dark:hover:bg-muted"
           >
             <Link href={`/recipe/${recipe.slug}`}>
               View Recipe

--- a/src/app/_components/FilterableRecipeSection.tsx
+++ b/src/app/_components/FilterableRecipeSection.tsx
@@ -55,10 +55,10 @@ export function FilterableRecipeSection({
   return (
     <section id="recipes" className="scroll-mt-8">
       <div className="mb-8">
-        <h2 className="mb-1 text-xl font-semibold tracking-tight text-neutral-900 dark:text-white">
+        <h2 className="mb-1 text-xl font-semibold tracking-tight text-foreground dark:text-foreground">
           Browse Recipes
         </h2>
-        <p className="mb-5 text-[15px] text-neutral-500 dark:text-neutral-400">
+        <p className="mb-5 text-[15px] text-muted-foreground dark:text-muted-foreground">
           Explore our collection of curated recipes
         </p>
         <CategoryPills

--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -1,29 +1,43 @@
-import { Zap } from "lucide-react";
 import Link from "next/link";
 import { ModeToggle } from "./ModeToggle";
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
   return (
-    <footer className="border-t border-slate-200 bg-white py-4 text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50">
-      <div className="container flex items-center justify-between font-semibold">
-        <Link href="/" className="text-md flex align-middle font-semibold">
-          <Zap size={16} className="fill-yellow-300" />
-          Hyper Recipe
+    <footer className="border-t border-border/80 bg-background py-6 text-foreground">
+      <div className="container flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <Link
+          href="/"
+          className="group flex items-center gap-2 text-sm font-medium"
+        >
+          <span
+            aria-hidden
+            className="inline-block h-2 w-2 rounded-sm bg-accent transition-transform duration-300 group-hover:scale-125"
+          />
+          <span className="font-display tracking-tight">Hyper Recipes</span>
         </Link>
-        <div className="flex items-center gap-4">
-          <span className="text-sm font-normal">
-            © {currentYear} Hyper Recipe. All rights reserved.{" "}
-            <Link href="/pricing" className="underline">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <span className="text-sm font-normal text-muted-foreground">
+            © {currentYear} Hyper Recipes.{" "}
+            <Link
+              href="/pricing"
+              className="underline decoration-border underline-offset-4 hover:text-foreground"
+            >
               Pricing
             </Link>{" "}
-            |{" "}
-            <Link href="/privacy" className="underline">
-              Privacy Policy
+            ·{" "}
+            <Link
+              href="/privacy"
+              className="underline decoration-border underline-offset-4 hover:text-foreground"
+            >
+              Privacy
             </Link>{" "}
-            |{" "}
-            <Link href="/terms" className="underline">
-              Terms and Conditions
+            ·{" "}
+            <Link
+              href="/terms"
+              className="underline decoration-border underline-offset-4 hover:text-foreground"
+            >
+              Terms
             </Link>
           </span>
           <ModeToggle />

--- a/src/app/_components/FooterCTA.tsx
+++ b/src/app/_components/FooterCTA.tsx
@@ -9,27 +9,22 @@ import { Button } from "@/components/ui/button";
  */
 export function FooterCTA(): JSX.Element {
   return (
-    <section className="relative overflow-hidden rounded-2xl bg-neutral-900 px-8 py-14 text-center">
-      <div className="absolute inset-0 bg-gradient-to-br from-neutral-800/50 via-transparent to-neutral-950/30" />
-      
-      <div 
-        className="absolute inset-0 opacity-[0.03]"
-        style={{
-          backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        }}
-      />
-      
+    <section className="relative overflow-hidden rounded-2xl bg-primary px-8 py-14 text-center text-primary-foreground">
+      <div className="pointer-events-none absolute -right-16 -top-16 h-48 w-48 rounded-full bg-accent/20 blur-2xl" />
+      <div className="pointer-events-none absolute -bottom-20 -left-10 h-56 w-56 rounded-full bg-herb/20 blur-2xl" />
+
       <div className="relative z-10">
-        <h2 className="mb-3 text-2xl font-semibold tracking-tight text-white md:text-3xl">
+        <h2 className="mb-3 font-display text-2xl font-semibold tracking-tight md:text-3xl">
           Unlock smart recipes in seconds.
         </h2>
-        <p className="mb-8 text-[15px] text-neutral-400">
+        <p className="mb-8 text-[15px] text-primary-foreground/70">
           Free account. Google login. Start cooking smarter today.
         </p>
         <SignInButton mode="modal">
-          <Button 
-            size="lg" 
-            className="h-12 rounded-xl bg-white px-8 text-[15px] font-medium text-neutral-900 shadow-lg transition-all hover:bg-neutral-100 hover:shadow-xl"
+          <Button
+            size="lg"
+            variant="secondary"
+            className="h-12 bg-card px-8 text-[15px] font-medium text-foreground hover:bg-card/90"
           >
             Create free account
           </Button>

--- a/src/app/_components/GreetingBar.tsx
+++ b/src/app/_components/GreetingBar.tsx
@@ -50,17 +50,17 @@ export function GreetingBar(): JSX.Element {
   return (
     <div className="flex items-center justify-between py-6">
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-white md:text-3xl">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground dark:text-foreground md:text-3xl">
           {greeting}, {displayName}
         </h1>
-        <p className="mt-1 text-[15px] text-neutral-500 dark:text-neutral-400">
+        <p className="mt-1 text-[15px] text-muted-foreground dark:text-muted-foreground">
           What are you cooking today?
         </p>
       </div>
 
       <Link
         href="/kitchen-journey"
-        className="flex items-center gap-3 rounded-2xl border border-neutral-200 bg-white px-4 py-2.5 transition-all hover:border-neutral-300 hover:shadow-sm dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+        className="flex items-center gap-3 rounded-2xl border border-border bg-card px-4 py-2.5 transition-all hover:border-foreground/15 hover:shadow-sm dark:border-border dark:bg-card dark:hover:border-border"
       >
         <div
           className="relative flex h-10 w-10 items-center justify-center rounded-full"
@@ -70,15 +70,15 @@ export function GreetingBar(): JSX.Element {
               : `conic-gradient(rgb(34 197 94) ${progress.percentage}%, rgb(229 231 235) ${progress.percentage}%)`,
           }}
         >
-          <div className="absolute inset-[2px] flex items-center justify-center rounded-full bg-white dark:bg-neutral-900">
-            <Trophy className="h-5 w-5 text-amber-500" />
+          <div className="absolute inset-[2px] flex items-center justify-center rounded-full bg-card dark:bg-card">
+            <Trophy className="h-5 w-5 text-accent" />
           </div>
         </div>
         <div className="hidden sm:block">
-          <p className="text-sm font-medium text-neutral-900 dark:text-white">
+          <p className="text-sm font-medium text-foreground dark:text-foreground">
             Level {progress.level}
           </p>
-          <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          <p className="text-xs text-muted-foreground dark:text-muted-foreground">
             Kitchen Journey
           </p>
         </div>

--- a/src/app/_components/InlineSignupPrompt.tsx
+++ b/src/app/_components/InlineSignupPrompt.tsx
@@ -10,18 +10,18 @@ import { Sparkles } from "lucide-react";
  */
 export function InlineSignupPrompt(): JSX.Element {
   return (
-    <div className="col-span-full flex items-center justify-between gap-6 rounded-2xl border border-neutral-200/80 bg-gradient-to-r from-neutral-50 to-white px-6 py-5 dark:border-neutral-800 dark:from-neutral-900 dark:to-neutral-900/50">
+    <div className="col-span-full flex items-center justify-between gap-6 rounded-2xl border border-border/80 bg-gradient-to-r from-muted to-card px-6 py-5 dark:border-border dark:from-card dark:to-muted/50">
       <div className="flex items-center gap-4">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-neutral-900 dark:bg-white">
-          <Sparkles className="h-5 w-5 text-white dark:text-neutral-900" />
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary dark:bg-card">
+          <Sparkles className="h-5 w-5 text-white dark:text-foreground" />
         </div>
         <div>
-          <p className="text-[15px] font-medium text-neutral-900 dark:text-white">Save recipes to your collection</p>
-          <p className="text-[14px] text-neutral-500 dark:text-neutral-400">Sign in to favorite, track, and organize your recipes</p>
+          <p className="text-[15px] font-medium text-foreground dark:text-foreground">Save recipes to your collection</p>
+          <p className="text-[14px] text-muted-foreground dark:text-muted-foreground">Sign in to favorite, track, and organize your recipes</p>
         </div>
       </div>
       <Button 
-        className="shrink-0 rounded-xl bg-neutral-900 px-5 text-[14px] font-medium shadow-sm transition-all hover:bg-neutral-800 hover:shadow-md dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-100"
+        className="shrink-0 rounded-xl bg-primary px-5 text-[14px] font-medium shadow-sm transition-all hover:bg-muted hover:shadow-md dark:bg-card dark:text-foreground dark:hover:bg-muted"
       >
         <SignInButton mode="modal">
           Sign in

--- a/src/app/_components/KitchenJourneyBadge.tsx
+++ b/src/app/_components/KitchenJourneyBadge.tsx
@@ -59,8 +59,8 @@ export default function KitchenJourneyBadge() {
                   : `conic-gradient(rgb(34 197 94) ${progress.percentage}%, rgb(226 232 240) ${progress.percentage}%)`,
               }}
             >
-              <div className="absolute inset-[2px] flex items-center justify-center rounded-full bg-white transition-transform dark:bg-slate-950">
-                <Trophy className="h-5 w-5 fill-yellow-300 dark:fill-yellow-300" />
+              <div className="absolute inset-[2px] flex items-center justify-center rounded-full bg-card transition-transform dark:bg-background">
+                <Trophy className="h-5 w-5 fill-accent dark:fill-accent" />
               </div>
             </div>
             {isLoading ? (
@@ -86,9 +86,9 @@ export default function KitchenJourneyBadge() {
                 <p className="-mt-0.5 text-xs text-muted-foreground">
                   {progress.xp}/{progress.nextLevelXp} XP
                 </p>
-                <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200">
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
                   <div
-                    className="h-full rounded-full bg-emerald-500"
+                    className="h-full rounded-full bg-herb"
                     style={{ width: `${progress.percentage}%` }}
                   />
                 </div>

--- a/src/app/_components/QuickActions.tsx
+++ b/src/app/_components/QuickActions.tsx
@@ -60,8 +60,8 @@ export function QuickActions(): JSX.Element {
           className={cn(
             "flex items-center gap-3 rounded-xl px-4 py-3 transition-all duration-150",
             action.variant === "primary"
-              ? "bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-100"
-              : "border border-neutral-200 bg-white text-neutral-700 hover:border-neutral-300 hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-700 dark:hover:bg-neutral-800"
+              ? "bg-primary text-white hover:bg-muted dark:bg-card dark:text-foreground dark:hover:bg-muted"
+              : "border border-border bg-card text-foreground/80 hover:border-foreground/15 hover:bg-muted dark:border-border dark:bg-card dark:text-foreground dark:hover:border-border dark:hover:bg-muted"
           )}
         >
           {action.icon}
@@ -71,8 +71,8 @@ export function QuickActions(): JSX.Element {
               className={cn(
                 "text-[12px]",
                 action.variant === "primary"
-                  ? "text-neutral-400 dark:text-neutral-500"
-                  : "text-neutral-500 dark:text-neutral-400"
+                  ? "text-muted-foreground dark:text-muted-foreground"
+                  : "text-muted-foreground dark:text-muted-foreground"
               )}
             >
               {action.description}

--- a/src/app/_components/RecipeCard.tsx
+++ b/src/app/_components/RecipeCard.tsx
@@ -9,11 +9,11 @@ import { Soup } from "lucide-react";
  */
 function RecipeCard({ recipe }: { recipe: Recipe }): JSX.Element {
   return (
-    <Link 
+    <Link
       href={`/recipe/${recipe.slug}`}
-      className="group block h-full overflow-hidden rounded-2xl border border-neutral-200/60 bg-white transition-all duration-200 hover:border-neutral-300 hover:shadow-lg hover:shadow-neutral-200/50 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700 dark:hover:shadow-neutral-950/50"
+      className="group block h-full overflow-hidden rounded-2xl border border-border bg-card transition-all duration-200 hover:border-foreground/15 hover:shadow-lift"
     >
-      <div className="relative aspect-[4/3] overflow-hidden bg-neutral-100 dark:bg-neutral-800">
+      <div className="relative aspect-[4/3] overflow-hidden bg-muted">
         {recipe.heroImage?.url ? (
           <Image
             src={recipe.heroImage.url}
@@ -24,15 +24,15 @@ function RecipeCard({ recipe }: { recipe: Recipe }): JSX.Element {
           />
         ) : (
           <div className="flex h-full items-center justify-center">
-            <Soup size={48} className="text-neutral-300 dark:text-neutral-600" />
+            <Soup size={48} className="text-muted-foreground/40" />
           </div>
         )}
       </div>
       <div className="p-5">
-        <h3 className="mb-2 text-[17px] font-semibold leading-snug tracking-tight text-neutral-900 transition-colors group-hover:text-neutral-700 dark:text-white dark:group-hover:text-neutral-200">
+        <h3 className="mb-2 font-display text-[17px] font-semibold leading-snug tracking-tight text-foreground transition-colors group-hover:text-accent">
           {recipe.name}
         </h3>
-        <p className="line-clamp-2 text-[14px] leading-relaxed text-neutral-500 dark:text-neutral-400">
+        <p className="line-clamp-2 text-[14px] leading-relaxed text-muted-foreground">
           {recipe.description}
         </p>
       </div>

--- a/src/app/_components/RecipeCardSkeleton.tsx
+++ b/src/app/_components/RecipeCardSkeleton.tsx
@@ -1,15 +1,17 @@
+import React from "react";
+
 /**
  * Skeleton loader for recipe cards with refined styling.
  */
 export default function RecipeCardSkeleton(): JSX.Element {
   return (
-    <div className="h-full overflow-hidden rounded-2xl border border-neutral-200/60 bg-white dark:border-neutral-800 dark:bg-neutral-900">
-      <div className="aspect-[4/3] animate-pulse bg-neutral-100 dark:bg-neutral-800" />
+    <div className="h-full overflow-hidden rounded-2xl border border-border bg-card">
+      <div className="aspect-[4/3] animate-pulse bg-muted" />
       <div className="p-5">
-        <div className="mb-3 h-5 w-3/4 animate-pulse rounded-md bg-neutral-100 dark:bg-neutral-800" />
+        <div className="mb-3 h-5 w-3/4 animate-pulse rounded-md bg-muted" />
         <div className="space-y-2">
-          <div className="h-4 w-full animate-pulse rounded-md bg-neutral-100 dark:bg-neutral-800" />
-          <div className="h-4 w-2/3 animate-pulse rounded-md bg-neutral-100 dark:bg-neutral-800" />
+          <div className="h-4 w-full animate-pulse rounded-md bg-muted" />
+          <div className="h-4 w-2/3 animate-pulse rounded-md bg-muted" />
         </div>
       </div>
     </div>

--- a/src/app/_components/RecipeDialog.tsx
+++ b/src/app/_components/RecipeDialog.tsx
@@ -80,7 +80,7 @@ export default async function RecipeDialog({ recipe }: { recipe: Recipe }) {
                 <form action={() => toggleFavorite(recipe.id, isFavorite)}>
                   <Button type="submit" variant="secondary" size="default">
                     <Star
-                      className={`mr-2 h-5 w-5 transition-all active:-translate-y-1 ${isFavorite ? "fill-amber-400" : ""}`}
+                      className={`mr-2 h-5 w-5 transition-all active:-translate-y-1 ${isFavorite ? "fill-accent" : ""}`}
                     />
                     Favorite
                   </Button>

--- a/src/app/_components/RecipeGrid.tsx
+++ b/src/app/_components/RecipeGrid.tsx
@@ -25,8 +25,8 @@ export function RecipeGrid({
 
   if (!recipes || recipes.length === 0) {
     return (
-      <div className="flex min-h-[200px] items-center justify-center rounded-2xl border border-dashed border-neutral-200 bg-neutral-50/50 dark:border-neutral-800 dark:bg-neutral-900/50">
-        <p className="text-[15px] text-neutral-400 dark:text-neutral-500">
+      <div className="flex min-h-[200px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/50 dark:border-border dark:bg-card/50">
+        <p className="text-[15px] text-muted-foreground dark:text-muted-foreground">
           No recipes found
         </p>
       </div>

--- a/src/app/_components/SocialProofStrip.tsx
+++ b/src/app/_components/SocialProofStrip.tsx
@@ -4,11 +4,11 @@
  */
 export function SocialProofStrip(): JSX.Element {
   return (
-    <div className="rounded-2xl border border-neutral-200/60 bg-neutral-50 px-8 py-10 text-center dark:border-neutral-800 dark:bg-neutral-900/50">
-      <p className="text-lg font-medium text-neutral-900 dark:text-white">
+    <div className="rounded-2xl border border-border bg-muted/50 px-8 py-10 text-center">
+      <p className="font-display text-lg font-medium text-foreground">
         Built for home cooks who want better results—not more scrolling.
       </p>
-      <p className="mt-2 text-[14px] text-neutral-500 dark:text-neutral-400">
+      <p className="mt-2 text-[14px] text-muted-foreground">
         Designed as a cooking tool first, not a content farm.
       </p>
     </div>

--- a/src/app/_components/TaggedRecipes.tsx
+++ b/src/app/_components/TaggedRecipes.tsx
@@ -130,8 +130,8 @@ export default function TaggedRecipes({
   };
 
   return (
-    <Card className="w-full overflow-hidden border-2 border-amber-50 shadow-sm">
-      <CardHeader className="bg-gradient-to-r from-amber-50 to-amber-100/50 pb-3">
+    <Card className="w-full overflow-hidden border-2 border-accent/40 shadow-sm">
+      <CardHeader className="bg-gradient-to-r from-accent/10 to-accent/5 pb-3">
         <div className="flex items-center justify-between">
           <div>
             <CardTitle className="text-lg">Find Recipes By Category</CardTitle>
@@ -235,7 +235,7 @@ export default function TaggedRecipes({
           </Popover>
         </div>
         {selectedTag && (
-          <div className="mt-4 inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800">
+          <div className="mt-4 inline-flex items-center rounded-full bg-accent/10 px-3 py-1 text-sm font-medium text-accent">
             {getTagTypeIcon(selectedTag.tagType)}
             {selectedTag.tagType}: {selectedTag.name}
           </div>
@@ -245,8 +245,8 @@ export default function TaggedRecipes({
         {selectedTag ? (
           isChanging ? (
             <div className="flex h-48 flex-col items-center justify-center rounded-lg border border-dashed bg-gray-50/50 p-12 text-center">
-              <Loader2 className="h-8 w-8 animate-spin text-amber-600" />
-              <p className="mt-2 text-sm text-slate-500">Loading recipes...</p>
+              <Loader2 className="h-8 w-8 animate-spin text-accent" />
+              <p className="mt-2 text-sm text-muted-foreground">Loading recipes...</p>
             </div>
           ) : selectedTag.id in renderedCarousels ? (
             renderedCarousels[selectedTag.id]
@@ -255,8 +255,8 @@ export default function TaggedRecipes({
           )
         ) : (
           <div className="flex h-48 flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-12 text-center">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-amber-100">
-              <UtensilsCrossed className="h-6 w-6 text-amber-600" />
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-accent/10">
+              <UtensilsCrossed className="h-6 w-6 text-accent" />
             </div>
             <h3 className="mt-2 text-sm font-semibold text-gray-900">
               No category selected

--- a/src/app/_components/TopNav.tsx
+++ b/src/app/_components/TopNav.tsx
@@ -10,7 +10,7 @@ import {
 import Link from "next/link";
 import { CommandSearch } from "./CommandSearch";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { LayoutDashboard, PlusCircle, Zap } from "lucide-react";
+import { LayoutDashboard, PlusCircle } from "lucide-react";
 import KitchenJourneyBadge from "./KitchenJourneyBadge";
 
 /**
@@ -23,15 +23,20 @@ export default function TopNav(): JSX.Element {
   const isAdmin = user?.publicMetadata?.role === "admin";
 
   return (
-    <div className="border-b border-slate-200 bg-white py-3 text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50 md:py-4">
-      <nav className="container flex items-center justify-between gap-2 font-semibold md:gap-4">
+    <div className="border-b border-border/80 bg-background/95 py-3 text-foreground backdrop-blur-sm md:py-4">
+      <nav className="container flex items-center justify-between gap-2 md:gap-4">
         <Link
           href="/"
-          className="flex shrink-0 items-center gap-1 text-base font-semibold md:text-xl"
+          className="group flex shrink-0 items-center gap-2 text-base font-medium md:text-lg"
         >
-          <Zap size={16} className="fill-yellow-300" />
-          <span className="hidden sm:inline">Hyper Recipe</span>
-          <span className="sm:hidden">Hyper</span>
+          <span
+            aria-hidden
+            className="inline-block h-2.5 w-2.5 rounded-sm bg-accent transition-transform duration-300 group-hover:scale-125"
+          />
+          <span className="font-display tracking-tight">
+            <span className="hidden sm:inline">Hyper Recipes</span>
+            <span className="sm:hidden">Hyper</span>
+          </span>
         </Link>
 
         <div className="flex flex-1 justify-center">
@@ -85,7 +90,7 @@ export default function TopNav(): JSX.Element {
             <div className="hidden md:block">
               <KitchenJourneyBadge />
             </div>
-            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-500 md:h-9 md:w-9">
+            <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full ring-1 ring-border md:h-9 md:w-9">
               <UserButton />
             </div>
           </SignedIn>

--- a/src/app/_components/UpsellStrip.tsx
+++ b/src/app/_components/UpsellStrip.tsx
@@ -8,13 +8,13 @@ import { buttonVariants } from "@/components/ui/button";
  */
 export function UpsellStrip(): JSX.Element {
   return (
-    <div className="border-b border-neutral-200/60 bg-neutral-50/80 py-3 dark:border-neutral-800 dark:bg-neutral-900/30">
+    <div className="border-b border-border/60 bg-herb-muted/60 py-3">
       <div className="container mx-auto flex flex-col items-center gap-3 px-4 sm:flex-row sm:justify-between sm:gap-4">
         <div className="flex flex-col items-center gap-1 text-center sm:items-start sm:text-left">
-          <p className="text-sm font-medium text-neutral-900 dark:text-white sm:text-base">
+          <p className="text-sm font-medium text-foreground sm:text-base">
             Unlock Pro: meal planning, smarter swaps, and premium features.
           </p>
-          <p className="hidden text-xs text-neutral-500 dark:text-neutral-400 md:block">
+          <p className="hidden text-xs text-muted-foreground md:block">
             Monthly or annual. Cancel anytime.
           </p>
         </div>
@@ -32,4 +32,3 @@ export function UpsellStrip(): JSX.Element {
     </div>
   );
 }
-

--- a/src/app/_components/WhyBetterSection.tsx
+++ b/src/app/_components/WhyBetterSection.tsx
@@ -39,7 +39,7 @@ export function WhyBetterSection(): JSX.Element {
   return (
     <section>
       <div className="mb-10 text-center">
-        <h2 className="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-white md:text-3xl">
+        <h2 className="font-display text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
           Why Hyper Recipes beats traditional recipe blogs
         </h2>
       </div>
@@ -48,15 +48,15 @@ export function WhyBetterSection(): JSX.Element {
         {VALUE_POINTS.map((point) => (
           <div
             key={point.title}
-            className="rounded-2xl border border-neutral-200/60 bg-white p-6 transition-all hover:border-neutral-300 hover:shadow-sm dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+            className="rounded-2xl border border-border bg-card p-6 transition-all hover:border-foreground/15 hover:shadow-soft"
           >
-            <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
+            <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-herb-muted text-herb">
               {point.icon}
             </div>
-            <h3 className="mb-2 text-[16px] font-semibold tracking-tight text-neutral-900 dark:text-white">
+            <h3 className="mb-2 font-display text-[16px] font-semibold tracking-tight text-foreground">
               {point.title}
             </h3>
-            <p className="text-[14px] leading-relaxed text-neutral-500 dark:text-neutral-400">
+            <p className="text-[14px] leading-relaxed text-muted-foreground">
               {point.description}
             </p>
           </div>
@@ -65,4 +65,3 @@ export function WhyBetterSection(): JSX.Element {
     </section>
   );
 }
-

--- a/src/app/_components/logged-in-homepage/ContinueRow.tsx
+++ b/src/app/_components/logged-in-homepage/ContinueRow.tsx
@@ -50,11 +50,11 @@ export function ContinueRow({ recipes }: ContinueRowProps): JSX.Element {
   if (recentRecipes.length === 0) {
     return (
       <section className="py-2">
-        <h2 className="mb-4 text-lg font-semibold tracking-tight text-neutral-900 dark:text-white">
+        <h2 className="mb-4 font-display text-lg font-semibold tracking-tight text-foreground dark:text-foreground">
           Continue
         </h2>
-        <div className="flex items-center justify-center rounded-2xl border border-dashed border-neutral-200 bg-neutral-50/50 py-8 dark:border-neutral-800 dark:bg-neutral-900/50">
-          <p className="text-[15px] text-neutral-500 dark:text-neutral-400">
+        <div className="flex items-center justify-center rounded-2xl border border-dashed border-border bg-muted/50 py-8 dark:border-border dark:bg-card/50">
+          <p className="text-[15px] text-muted-foreground dark:text-muted-foreground">
             Nothing yet. Save a recipe or start cooking to build your home feed.
           </p>
         </div>
@@ -64,7 +64,7 @@ export function ContinueRow({ recipes }: ContinueRowProps): JSX.Element {
 
   return (
     <section className="py-2">
-      <h2 className="mb-4 text-lg font-semibold tracking-tight text-neutral-900 dark:text-white">
+      <h2 className="mb-4 font-display text-lg font-semibold tracking-tight text-foreground dark:text-foreground">
         Continue
       </h2>
       <div className="scrollbar-hide -mx-1 flex gap-4 overflow-x-auto px-1 pb-2">
@@ -90,10 +90,10 @@ function ContinueCard({ recipe }: ContinueCardProps): JSX.Element {
   return (
     <Link
       href={`/recipe/${recipe.slug}`}
-      className="group flex w-[240px] shrink-0 gap-3 rounded-xl border border-neutral-200/60 bg-white p-3 transition-all duration-200 hover:border-neutral-300 hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+      className="group flex w-[240px] shrink-0 gap-3 rounded-xl border border-border bg-card p-3 transition-all duration-200 hover:border-foreground/15 hover:shadow-md dark:border-border dark:bg-card dark:hover:border-border"
     >
       {/* Small image */}
-      <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-lg bg-neutral-100 dark:bg-neutral-800">
+      <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-lg bg-muted dark:bg-muted">
         {recipe.heroImage?.url ? (
           <Image
             src={recipe.heroImage.url}
@@ -104,7 +104,7 @@ function ContinueCard({ recipe }: ContinueCardProps): JSX.Element {
           />
         ) : (
           <div className="flex h-full items-center justify-center">
-            <Soup size={24} className="text-neutral-300 dark:text-neutral-600" />
+            <Soup size={24} className="text-muted-foreground/40 dark:text-muted-foreground" />
           </div>
         )}
       </div>
@@ -112,10 +112,10 @@ function ContinueCard({ recipe }: ContinueCardProps): JSX.Element {
       {/* Info */}
       <div className="flex min-w-0 flex-1 flex-col justify-between">
         <div>
-          <h3 className="truncate text-[14px] font-medium text-neutral-900 dark:text-white">
+          <h3 className="truncate text-[14px] font-medium text-foreground dark:text-foreground">
             {recipe.name}
           </h3>
-          <div className="mt-0.5 flex items-center gap-2 text-[12px] text-neutral-500 dark:text-neutral-400">
+          <div className="mt-0.5 flex items-center gap-2 text-[12px] text-muted-foreground dark:text-muted-foreground">
             {timeDisplay && (
               <span className="flex items-center gap-0.5">
                 <Clock className="h-3 w-3" />
@@ -133,7 +133,7 @@ function ContinueCard({ recipe }: ContinueCardProps): JSX.Element {
         <Button
           variant="ghost"
           size="sm"
-          className="mt-1 h-7 w-fit gap-1 px-2 text-[12px] text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white"
+          className="mt-1 h-7 w-fit gap-1 px-2 text-[12px] text-muted-foreground hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground"
         >
           <PlayCircle className="h-3.5 w-3.5" />
           Resume
@@ -149,20 +149,20 @@ function ContinueCard({ recipe }: ContinueCardProps): JSX.Element {
 export function ContinueRowSkeleton(): JSX.Element {
   return (
     <section className="py-2">
-      <div className="mb-4 h-6 w-24 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+      <div className="mb-4 h-6 w-24 animate-pulse rounded bg-muted dark:bg-muted" />
       <div className="flex gap-4 overflow-x-auto pb-2">
         {Array.from({ length: 4 }, (_, i) => (
           <div
             key={i}
-            className="flex w-[240px] shrink-0 gap-3 rounded-xl border border-neutral-200/60 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-900"
+            className="flex w-[240px] shrink-0 gap-3 rounded-xl border border-border bg-card p-3 dark:border-border dark:bg-card"
           >
-            <div className="h-16 w-16 shrink-0 animate-pulse rounded-lg bg-neutral-100 dark:bg-neutral-800" />
+            <div className="h-16 w-16 shrink-0 animate-pulse rounded-lg bg-muted dark:bg-muted" />
             <div className="flex flex-1 flex-col justify-between">
               <div>
-                <div className="h-4 w-full animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
-                <div className="mt-1 h-3 w-2/3 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+                <div className="h-4 w-full animate-pulse rounded bg-muted dark:bg-muted" />
+                <div className="mt-1 h-3 w-2/3 animate-pulse rounded bg-muted dark:bg-muted" />
               </div>
-              <div className="h-6 w-16 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+              <div className="h-6 w-16 animate-pulse rounded bg-muted dark:bg-muted" />
             </div>
           </div>
         ))}

--- a/src/app/_components/logged-in-homepage/CookNowSpotlight.tsx
+++ b/src/app/_components/logged-in-homepage/CookNowSpotlight.tsx
@@ -59,18 +59,17 @@ export function CookNowSpotlight({ recipes }: CookNowSpotlightProps): JSX.Elemen
   const timeDisplay = formatTime(spotlightRecipe.prepTime, spotlightRecipe.cookTime);
 
   return (
-    <section className="relative overflow-hidden rounded-3xl border border-neutral-200/60 bg-gradient-to-br from-white to-neutral-50 dark:border-neutral-800 dark:from-neutral-900 dark:to-neutral-900/80">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-amber-100/30 via-transparent to-transparent dark:from-amber-900/10" />
-      
+    <section className="relative overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-card to-muted dark:border-border dark:from-card dark:to-muted/80">
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-accent/10 via-transparent to-transparent" />
       <div className="relative p-6 md:p-8">
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold tracking-tight text-neutral-900 dark:text-white">
+          <h2 className="font-display text-lg font-semibold tracking-tight text-foreground dark:text-foreground">
             Cook now
           </h2>
           <Button
             variant="ghost"
             size="sm"
-            className="gap-2 text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white"
+            className="gap-2 text-muted-foreground hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground"
             onClick={handleSwap}
           >
             <Shuffle className="h-4 w-4" />
@@ -80,7 +79,7 @@ export function CookNowSpotlight({ recipes }: CookNowSpotlightProps): JSX.Elemen
 
         <div className="grid gap-6 md:grid-cols-[280px_1fr]">
           {/* Recipe Image */}
-          <div className="relative aspect-[4/3] overflow-hidden rounded-2xl bg-neutral-100 dark:bg-neutral-800 md:aspect-square">
+          <div className="relative aspect-[4/3] overflow-hidden rounded-2xl bg-muted dark:bg-muted md:aspect-square">
             {spotlightRecipe.heroImage?.url ? (
               <Image
                 src={spotlightRecipe.heroImage.url}
@@ -92,7 +91,7 @@ export function CookNowSpotlight({ recipes }: CookNowSpotlightProps): JSX.Elemen
               />
             ) : (
               <div className="flex h-full items-center justify-center">
-                <Soup size={64} className="text-neutral-300 dark:text-neutral-600" />
+                <Soup size={64} className="text-muted-foreground/40 dark:text-muted-foreground" />
               </div>
             )}
           </div>
@@ -100,11 +99,11 @@ export function CookNowSpotlight({ recipes }: CookNowSpotlightProps): JSX.Elemen
           {/* Recipe Info */}
           <div className="flex flex-col justify-between">
             <div>
-              <h3 className="mb-2 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-white md:text-3xl">
+              <h3 className="mb-2 font-display text-2xl font-semibold tracking-tight text-foreground dark:text-foreground md:text-3xl">
                 {spotlightRecipe.name}
               </h3>
               
-              <p className="mb-4 line-clamp-2 text-[15px] leading-relaxed text-neutral-600 dark:text-neutral-400">
+              <p className="mb-4 line-clamp-2 text-[15px] leading-relaxed text-muted-foreground dark:text-muted-foreground">
                 {spotlightRecipe.description}
               </p>
 
@@ -151,26 +150,26 @@ export function CookNowSpotlight({ recipes }: CookNowSpotlightProps): JSX.Elemen
  */
 export function CookNowSpotlightSkeleton(): JSX.Element {
   return (
-    <section className="overflow-hidden rounded-3xl border border-neutral-200/60 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900 md:p-8">
+    <section className="overflow-hidden rounded-3xl border border-border bg-card p-6 dark:border-border dark:bg-card md:p-8">
       <div className="mb-4 flex items-center justify-between">
-        <div className="h-6 w-24 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
-        <div className="h-9 w-36 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+        <div className="h-6 w-24 animate-pulse rounded bg-muted dark:bg-muted" />
+        <div className="h-9 w-36 animate-pulse rounded bg-muted dark:bg-muted" />
       </div>
       <div className="grid gap-6 md:grid-cols-[280px_1fr]">
-        <div className="aspect-[4/3] animate-pulse rounded-2xl bg-neutral-100 dark:bg-neutral-800 md:aspect-square" />
+        <div className="aspect-[4/3] animate-pulse rounded-2xl bg-muted dark:bg-muted md:aspect-square" />
         <div className="flex flex-col justify-between">
           <div>
-            <div className="mb-2 h-9 w-3/4 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
-            <div className="mb-4 h-12 w-full animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+            <div className="mb-2 h-9 w-3/4 animate-pulse rounded bg-muted dark:bg-muted" />
+            <div className="mb-4 h-12 w-full animate-pulse rounded bg-muted dark:bg-muted" />
             <div className="mb-6 flex gap-3">
-              <div className="h-8 w-20 animate-pulse rounded-full bg-neutral-100 dark:bg-neutral-800" />
-              <div className="h-8 w-16 animate-pulse rounded-full bg-neutral-100 dark:bg-neutral-800" />
+              <div className="h-8 w-20 animate-pulse rounded-full bg-muted dark:bg-muted" />
+              <div className="h-8 w-16 animate-pulse rounded-full bg-muted dark:bg-muted" />
             </div>
           </div>
           <div className="flex gap-3">
-            <div className="h-11 w-32 animate-pulse rounded-lg bg-neutral-100 dark:bg-neutral-800" />
-            <div className="h-11 w-11 animate-pulse rounded-lg bg-neutral-100 dark:bg-neutral-800" />
-            <div className="h-11 w-11 animate-pulse rounded-lg bg-neutral-100 dark:bg-neutral-800" />
+            <div className="h-11 w-32 animate-pulse rounded-lg bg-muted dark:bg-muted" />
+            <div className="h-11 w-11 animate-pulse rounded-lg bg-muted dark:bg-muted" />
+            <div className="h-11 w-11 animate-pulse rounded-lg bg-muted dark:bg-muted" />
           </div>
         </div>
       </div>

--- a/src/app/_components/logged-in-homepage/ExploreGrid.tsx
+++ b/src/app/_components/logged-in-homepage/ExploreGrid.tsx
@@ -67,10 +67,10 @@ export function ExploreGrid({
   return (
     <section className="py-2">
       <div className="mb-6">
-        <h2 className="mb-1 text-xl font-semibold tracking-tight text-neutral-900 dark:text-white">
+        <h2 className="mb-1 font-display text-xl font-semibold tracking-tight text-foreground">
           Explore smart recipes
         </h2>
-        <p className="mb-5 text-[15px] text-neutral-500 dark:text-neutral-400">
+        <p className="mb-5 text-[15px] text-muted-foreground dark:text-muted-foreground">
           Discover recipes that adapt to your needs
         </p>
         <QuickFilters
@@ -80,8 +80,8 @@ export function ExploreGrid({
       </div>
 
       {displayedRecipes.length === 0 ? (
-        <div className="flex items-center justify-center rounded-2xl border border-dashed border-neutral-200 bg-neutral-50/50 py-12 dark:border-neutral-800 dark:bg-neutral-900/50">
-          <p className="text-[15px] text-neutral-500 dark:text-neutral-400">
+        <div className="flex items-center justify-center rounded-2xl border border-dashed border-border bg-muted/50 py-12 dark:border-border dark:bg-card/50">
+          <p className="text-[15px] text-muted-foreground dark:text-muted-foreground">
             No recipes match your filters. Try removing some filters.
           </p>
         </div>
@@ -122,8 +122,8 @@ export function ExploreGridSkeleton(): JSX.Element {
   return (
     <section className="py-2">
       <div className="mb-6">
-        <div className="mb-1 h-7 w-48 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
-        <div className="mb-5 h-5 w-64 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+        <div className="mb-1 h-7 w-48 animate-pulse rounded bg-muted dark:bg-muted" />
+        <div className="mb-5 h-5 w-64 animate-pulse rounded bg-muted dark:bg-muted" />
         <QuickFiltersSkeleton />
       </div>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">

--- a/src/app/_components/logged-in-homepage/FooterMicroCTA.tsx
+++ b/src/app/_components/logged-in-homepage/FooterMicroCTA.tsx
@@ -5,10 +5,10 @@
 export function FooterMicroCTA(): JSX.Element {
   return (
     <div className="mt-12 flex flex-col items-center justify-center py-8 text-center">
-      <p className="text-[15px] font-medium text-neutral-700 dark:text-neutral-300">
+      <p className="text-[15px] font-medium text-foreground/80 dark:text-muted-foreground/40">
         Pro tip: Save your best tweaks.
       </p>
-      <p className="mt-1 text-[13px] text-neutral-500 dark:text-neutral-400">
+      <p className="mt-1 text-[13px] text-muted-foreground dark:text-muted-foreground">
         Hyper Recipes gets better when you keep your swaps and notes.
       </p>
     </div>

--- a/src/app/_components/logged-in-homepage/HeaderStrip.tsx
+++ b/src/app/_components/logged-in-homepage/HeaderStrip.tsx
@@ -16,10 +16,10 @@ export function HeaderStrip(): JSX.Element {
   return (
     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-white md:text-3xl">
+        <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
           What are you cooking today?
         </h1>
-        <p className="mt-1 text-[15px] text-neutral-500 dark:text-neutral-400">
+        <p className="mt-1 text-[15px] text-muted-foreground dark:text-muted-foreground">
           Pick something fast, or continue where you left off.
         </p>
       </div>

--- a/src/app/_components/logged-in-homepage/QuickFilters.tsx
+++ b/src/app/_components/logged-in-homepage/QuickFilters.tsx
@@ -37,7 +37,7 @@ export function QuickFilters({
 }: QuickFiltersProps): JSX.Element {
   return (
     <div className="space-y-3">
-      <p className="text-[14px] font-medium text-neutral-600 dark:text-neutral-400">
+      <p className="text-[14px] font-medium text-muted-foreground dark:text-muted-foreground">
         Find something that fits...
       </p>
       <div className="scrollbar-hide flex gap-2 overflow-x-auto pb-1">
@@ -50,8 +50,8 @@ export function QuickFilters({
               className={cn(
                 "flex shrink-0 items-center gap-1.5 rounded-full px-3.5 py-2 text-[13px] font-medium transition-all duration-150",
                 isActive
-                  ? "bg-neutral-900 text-white shadow-sm dark:bg-white dark:text-neutral-900"
-                  : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200 hover:text-neutral-900 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:hover:text-white"
+                  ? "bg-primary text-white shadow-sm dark:bg-card dark:text-foreground"
+                  : "bg-muted text-muted-foreground hover:bg-secondary hover:text-foreground dark:bg-muted dark:text-muted-foreground/40 dark:hover:bg-muted dark:hover:text-foreground"
               )}
             >
               {filter.icon}
@@ -107,12 +107,12 @@ export function filterRecipesByQuickFilters(
 export function QuickFiltersSkeleton(): JSX.Element {
   return (
     <div className="space-y-3">
-      <div className="h-5 w-40 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+      <div className="h-5 w-40 animate-pulse rounded bg-muted dark:bg-muted" />
       <div className="flex gap-2 overflow-x-auto pb-1">
         {Array.from({ length: 6 }, (_, i) => (
           <div
             key={i}
-            className="h-9 w-24 shrink-0 animate-pulse rounded-full bg-neutral-100 dark:bg-neutral-800"
+            className="h-9 w-24 shrink-0 animate-pulse rounded-full bg-muted dark:bg-muted"
           />
         ))}
       </div>

--- a/src/app/_components/logged-in-homepage/Sidebar.tsx
+++ b/src/app/_components/logged-in-homepage/Sidebar.tsx
@@ -35,12 +35,12 @@ type SavedSectionProps = {
 function SavedSection({ favorites }: SavedSectionProps): JSX.Element {
   if (!favorites || favorites.length === 0) {
     return (
-      <section className="rounded-2xl border border-neutral-200/60 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+      <section className="rounded-2xl border border-border bg-card p-5 dark:border-border dark:bg-card">
         <div className="mb-4 flex items-center gap-2">
-          <Heart className="h-5 w-5 text-neutral-400" />
-          <h3 className="font-semibold text-neutral-900 dark:text-white">Saved</h3>
+          <Heart className="h-5 w-5 text-muted-foreground" />
+          <h3 className="font-semibold text-foreground dark:text-foreground">Saved</h3>
         </div>
-        <p className="text-[14px] text-neutral-500 dark:text-neutral-400">
+        <p className="text-[14px] text-muted-foreground dark:text-muted-foreground">
           Save recipes to build your shortlist.
         </p>
       </section>
@@ -48,15 +48,15 @@ function SavedSection({ favorites }: SavedSectionProps): JSX.Element {
   }
 
   return (
-    <section className="rounded-2xl border border-neutral-200/60 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+    <section className="rounded-2xl border border-border bg-card p-5 dark:border-border dark:bg-card">
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Heart className="h-5 w-5 text-neutral-400" />
-          <h3 className="font-semibold text-neutral-900 dark:text-white">Saved</h3>
+          <Heart className="h-5 w-5 text-muted-foreground" />
+          <h3 className="font-semibold text-foreground dark:text-foreground">Saved</h3>
         </div>
         <Link
           href="/favorites"
-          className="flex items-center gap-1 text-[13px] font-medium text-neutral-600 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white"
+          className="flex items-center gap-1 text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground"
         >
           View all
           <ArrowRight className="h-3.5 w-3.5" />
@@ -82,12 +82,12 @@ type ListsSectionProps = {
 function ListsSection({ collections }: ListsSectionProps): JSX.Element {
   if (!collections || collections.length === 0) {
     return (
-      <section className="rounded-2xl border border-neutral-200/60 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+      <section className="rounded-2xl border border-border bg-card p-5 dark:border-border dark:bg-card">
         <div className="mb-4 flex items-center gap-2">
-          <FolderPlus className="h-5 w-5 text-neutral-400" />
-          <h3 className="font-semibold text-neutral-900 dark:text-white">Lists</h3>
+          <FolderPlus className="h-5 w-5 text-muted-foreground" />
+          <h3 className="font-semibold text-foreground dark:text-foreground">Lists</h3>
         </div>
-        <p className="mb-3 text-[14px] text-neutral-500 dark:text-neutral-400">
+        <p className="mb-3 text-[14px] text-muted-foreground dark:text-muted-foreground">
           Make lists for your go-to meals.
         </p>
         <Link href="/collections">
@@ -100,15 +100,15 @@ function ListsSection({ collections }: ListsSectionProps): JSX.Element {
   }
 
   return (
-    <section className="rounded-2xl border border-neutral-200/60 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+    <section className="rounded-2xl border border-border bg-card p-5 dark:border-border dark:bg-card">
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <FolderPlus className="h-5 w-5 text-neutral-400" />
-          <h3 className="font-semibold text-neutral-900 dark:text-white">Lists</h3>
+          <FolderPlus className="h-5 w-5 text-muted-foreground" />
+          <h3 className="font-semibold text-foreground dark:text-foreground">Lists</h3>
         </div>
         <Link
           href="/collections"
-          className="flex items-center gap-1 text-[13px] font-medium text-neutral-600 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white"
+          className="flex items-center gap-1 text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground"
         >
           Manage lists
           <ArrowRight className="h-3.5 w-3.5" />
@@ -119,12 +119,12 @@ function ListsSection({ collections }: ListsSectionProps): JSX.Element {
           <Link
             key={collection.id}
             href={`/collections/${collection.id}`}
-            className="flex items-center justify-between rounded-lg px-2 py-2 transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-800"
+            className="flex items-center justify-between rounded-lg px-2 py-2 transition-colors hover:bg-muted dark:hover:bg-muted"
           >
-            <span className="text-[14px] font-medium text-neutral-700 dark:text-neutral-300">
+            <span className="text-[14px] font-medium text-foreground/80 dark:text-muted-foreground/40">
               {collection.title}
             </span>
-            <span className="text-[12px] text-neutral-400">
+            <span className="text-[12px] text-muted-foreground">
               {collection.recipes?.length ?? 0} recipes
             </span>
           </Link>
@@ -140,21 +140,21 @@ function ListsSection({ collections }: ListsSectionProps): JSX.Element {
  */
 function YourRecipesSection(): JSX.Element {
   return (
-    <section className="rounded-2xl border border-neutral-200/60 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+    <section className="rounded-2xl border border-border bg-card p-5 dark:border-border dark:bg-card">
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <BookOpen className="h-5 w-5 text-neutral-400" />
-          <h3 className="font-semibold text-neutral-900 dark:text-white">Your recipes</h3>
+          <BookOpen className="h-5 w-5 text-muted-foreground" />
+          <h3 className="font-semibold text-foreground dark:text-foreground">Your recipes</h3>
         </div>
         <Link
           href="/dashboard"
-          className="flex items-center gap-1 text-[13px] font-medium text-neutral-600 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white"
+          className="flex items-center gap-1 text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground"
         >
           View all
           <ArrowRight className="h-3.5 w-3.5" />
         </Link>
       </div>
-      <p className="text-[14px] text-neutral-500 dark:text-neutral-400">
+      <p className="text-[14px] text-muted-foreground dark:text-muted-foreground">
         Recipes you create will appear here.
       </p>
     </section>
@@ -172,9 +172,9 @@ function SidebarRecipeItem({ recipe }: SidebarRecipeItemProps): JSX.Element {
   return (
     <Link
       href={`/recipe/${recipe.slug}`}
-      className="flex items-center gap-3 rounded-lg transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-800"
+      className="flex items-center gap-3 rounded-lg transition-colors hover:bg-muted dark:hover:bg-muted"
     >
-      <div className="relative h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-neutral-100 dark:bg-neutral-800">
+      <div className="relative h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-muted dark:bg-muted">
         {recipe.heroImage?.url ? (
           <Image
             src={recipe.heroImage.url}
@@ -185,11 +185,11 @@ function SidebarRecipeItem({ recipe }: SidebarRecipeItemProps): JSX.Element {
           />
         ) : (
           <div className="flex h-full items-center justify-center">
-            <Soup size={16} className="text-neutral-300 dark:text-neutral-600" />
+            <Soup size={16} className="text-muted-foreground/40 dark:text-muted-foreground" />
           </div>
         )}
       </div>
-      <span className="truncate text-[14px] font-medium text-neutral-700 dark:text-neutral-300">
+      <span className="truncate text-[14px] font-medium text-foreground/80 dark:text-muted-foreground/40">
         {recipe.name}
       </span>
     </Link>
@@ -205,14 +205,14 @@ export function SidebarSkeleton(): JSX.Element {
       {Array.from({ length: 3 }, (_, i) => (
         <div
           key={i}
-          className="rounded-2xl border border-neutral-200/60 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900"
+          className="rounded-2xl border border-border bg-card p-5 dark:border-border dark:bg-card"
         >
-          <div className="mb-4 h-5 w-24 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+          <div className="mb-4 h-5 w-24 animate-pulse rounded bg-muted dark:bg-muted" />
           <div className="space-y-3">
             {Array.from({ length: 3 }, (_, j) => (
               <div key={j} className="flex items-center gap-3">
-                <div className="h-10 w-10 shrink-0 animate-pulse rounded-lg bg-neutral-100 dark:bg-neutral-800" />
-                <div className="h-4 w-full animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+                <div className="h-10 w-10 shrink-0 animate-pulse rounded-lg bg-muted dark:bg-muted" />
+                <div className="h-4 w-full animate-pulse rounded bg-muted dark:bg-muted" />
               </div>
             ))}
           </div>

--- a/src/app/_components/logged-in-homepage/SmartRecipeCard.tsx
+++ b/src/app/_components/logged-in-homepage/SmartRecipeCard.tsx
@@ -61,9 +61,9 @@ export function SmartRecipeCard({
   return (
     <Link
       href={`/recipe/${recipe.slug}`}
-      className="group block h-full overflow-hidden rounded-2xl border border-neutral-200/60 bg-white transition-all duration-200 hover:border-neutral-300 hover:shadow-lg hover:shadow-neutral-200/50 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700 dark:hover:shadow-neutral-950/50"
+      className="group block h-full overflow-hidden rounded-2xl border border-border bg-card transition-all duration-200 hover:border-foreground/15 hover:shadow-lg hover:shadow-lift dark:border-border dark:bg-card dark:hover:border-border dark:hover:shadow-lift"
     >
-      <div className="relative aspect-[4/3] overflow-hidden bg-neutral-100 dark:bg-neutral-800">
+      <div className="relative aspect-[4/3] overflow-hidden bg-muted dark:bg-muted">
         {recipe.heroImage?.url ? (
           <Image
             src={recipe.heroImage.url}
@@ -74,7 +74,7 @@ export function SmartRecipeCard({
           />
         ) : (
           <div className="flex h-full items-center justify-center">
-            <Soup size={48} className="text-neutral-300 dark:text-neutral-600" />
+            <Soup size={48} className="text-muted-foreground/40 dark:text-muted-foreground" />
           </div>
         )}
 
@@ -83,8 +83,8 @@ export function SmartRecipeCard({
             variant="ghost"
             size="icon"
             className={cn(
-              "absolute right-2 top-2 h-8 w-8 rounded-full bg-white/90 backdrop-blur-sm transition-all hover:bg-white dark:bg-neutral-900/90 dark:hover:bg-neutral-900",
-              isSaved && "text-red-500"
+              "absolute right-2 top-2 h-8 w-8 rounded-full bg-card/90 backdrop-blur-sm transition-all hover:bg-card dark:bg-card/90 dark:hover:bg-card",
+              isSaved && "text-destructive"
             )}
             onClick={handleSaveClick}
           >
@@ -94,12 +94,12 @@ export function SmartRecipeCard({
       </div>
 
       <div className="p-4">
-        <h3 className="mb-2 text-[16px] font-semibold leading-snug tracking-tight text-neutral-900 transition-colors group-hover:text-neutral-700 dark:text-white dark:group-hover:text-neutral-200">
+        <h3 className="mb-2 font-display text-[16px] font-semibold leading-snug tracking-tight text-foreground transition-colors group-hover:text-accent">
           {recipe.name}
         </h3>
 
         {/* Time and difficulty row */}
-        <div className="mb-3 flex items-center gap-3 text-[13px] text-neutral-500 dark:text-neutral-400">
+        <div className="mb-3 flex items-center gap-3 text-[13px] text-muted-foreground dark:text-muted-foreground">
           {timeDisplay && (
             <span className="flex items-center gap-1">
               <Clock className="h-3.5 w-3.5" />
@@ -134,8 +134,8 @@ export function SmartRecipeCard({
           <div className="flex items-center gap-2">
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="flex h-6 w-6 items-center justify-center rounded-md bg-neutral-100 dark:bg-neutral-800">
-                  <ArrowLeftRight className="h-3 w-3 text-neutral-500 dark:text-neutral-400" />
+                <div className="flex h-6 w-6 items-center justify-center rounded-md bg-muted dark:bg-muted">
+                  <ArrowLeftRight className="h-3 w-3 text-muted-foreground dark:text-muted-foreground" />
                 </div>
               </TooltipTrigger>
               <TooltipContent>
@@ -145,8 +145,8 @@ export function SmartRecipeCard({
 
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="flex h-6 w-6 items-center justify-center rounded-md bg-neutral-100 dark:bg-neutral-800">
-                  <Scale className="h-3 w-3 text-neutral-500 dark:text-neutral-400" />
+                <div className="flex h-6 w-6 items-center justify-center rounded-md bg-muted dark:bg-muted">
+                  <Scale className="h-3 w-3 text-muted-foreground dark:text-muted-foreground" />
                 </div>
               </TooltipTrigger>
               <TooltipContent>
@@ -156,8 +156,8 @@ export function SmartRecipeCard({
 
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="flex h-6 w-6 items-center justify-center rounded-md bg-neutral-100 dark:bg-neutral-800">
-                  <Timer className="h-3 w-3 text-neutral-500 dark:text-neutral-400" />
+                <div className="flex h-6 w-6 items-center justify-center rounded-md bg-muted dark:bg-muted">
+                  <Timer className="h-3 w-3 text-muted-foreground dark:text-muted-foreground" />
                 </div>
               </TooltipTrigger>
               <TooltipContent>
@@ -176,22 +176,22 @@ export function SmartRecipeCard({
  */
 export function SmartRecipeCardSkeleton(): JSX.Element {
   return (
-    <div className="h-full overflow-hidden rounded-2xl border border-neutral-200/60 bg-white dark:border-neutral-800 dark:bg-neutral-900">
-      <div className="relative aspect-[4/3] animate-pulse bg-neutral-100 dark:bg-neutral-800" />
+    <div className="h-full overflow-hidden rounded-2xl border border-border bg-card dark:border-border dark:bg-card">
+      <div className="relative aspect-[4/3] animate-pulse bg-muted dark:bg-muted" />
       <div className="p-4">
-        <div className="mb-2 h-5 w-3/4 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+        <div className="mb-2 h-5 w-3/4 animate-pulse rounded bg-muted dark:bg-muted" />
         <div className="mb-3 flex gap-3">
-          <div className="h-4 w-16 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
-          <div className="h-4 w-12 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800" />
+          <div className="h-4 w-16 animate-pulse rounded bg-muted dark:bg-muted" />
+          <div className="h-4 w-12 animate-pulse rounded bg-muted dark:bg-muted" />
         </div>
         <div className="mb-3 flex gap-1.5">
-          <div className="h-5 w-14 animate-pulse rounded-full bg-neutral-100 dark:bg-neutral-800" />
-          <div className="h-5 w-16 animate-pulse rounded-full bg-neutral-100 dark:bg-neutral-800" />
+          <div className="h-5 w-14 animate-pulse rounded-full bg-muted dark:bg-muted" />
+          <div className="h-5 w-16 animate-pulse rounded-full bg-muted dark:bg-muted" />
         </div>
         <div className="flex gap-2">
-          <div className="h-6 w-6 animate-pulse rounded-md bg-neutral-100 dark:bg-neutral-800" />
-          <div className="h-6 w-6 animate-pulse rounded-md bg-neutral-100 dark:bg-neutral-800" />
-          <div className="h-6 w-6 animate-pulse rounded-md bg-neutral-100 dark:bg-neutral-800" />
+          <div className="h-6 w-6 animate-pulse rounded-md bg-muted dark:bg-muted" />
+          <div className="h-6 w-6 animate-pulse rounded-md bg-muted dark:bg-muted" />
+          <div className="h-6 w-6 animate-pulse rounded-md bg-muted dark:bg-muted" />
         </div>
       </div>
     </div>

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -54,7 +54,7 @@ export default async function CollectionPage({
     <>
       <SignedOut>
         <div className="container py-8">
-          <p className="text-center text-neutral-500">
+          <p className="text-center text-muted-foreground">
             Please sign in to view collections.
           </p>
         </div>
@@ -75,15 +75,15 @@ export default async function CollectionPage({
           </div>
 
           <div className="mb-8">
-            <h1 className="text-3xl font-bold tracking-tight text-neutral-900 dark:text-white">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground dark:text-foreground">
               {collection.title}
             </h1>
             {collection.description && (
-              <p className="mt-2 text-[15px] text-neutral-500 dark:text-neutral-400">
+              <p className="mt-2 text-[15px] text-muted-foreground dark:text-muted-foreground">
                 {collection.description}
               </p>
             )}
-            <p className="mt-2 text-[14px] text-neutral-400 dark:text-neutral-500">
+            <p className="mt-2 text-[14px] text-muted-foreground dark:text-muted-foreground">
               {recipes.length} {recipes.length === 1 ? "recipe" : "recipes"}
             </p>
           </div>

--- a/src/app/collections/_components/CollectionCardWithActions.tsx
+++ b/src/app/collections/_components/CollectionCardWithActions.tsx
@@ -66,7 +66,7 @@ export function CollectionCardWithActions({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className="flex h-8 w-8 items-center justify-center rounded-md bg-white/90 shadow-sm backdrop-blur-sm transition-colors hover:bg-white dark:bg-neutral-900/90 dark:hover:bg-neutral-900"
+                className="flex h-8 w-8 items-center justify-center rounded-md bg-card/90 shadow-sm backdrop-blur-sm transition-colors hover:bg-card dark:bg-card/90 dark:hover:bg-card"
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -25,7 +25,7 @@ export default async function CollectionsPage(): Promise<JSX.Element> {
     <>
       <SignedOut>
         <div className="container py-8">
-          <p className="text-center text-neutral-500">
+          <p className="text-center text-muted-foreground">
             Please sign in to view your collections.
           </p>
         </div>
@@ -35,10 +35,10 @@ export default async function CollectionsPage(): Promise<JSX.Element> {
         <div className="container py-8">
           <div className="mb-8 flex items-center justify-between">
             <div>
-              <h1 className="text-3xl font-bold tracking-tight text-neutral-900 dark:text-white">
+              <h1 className="text-3xl font-bold tracking-tight text-foreground dark:text-foreground">
                 Your Collections
               </h1>
-              <p className="mt-2 text-[15px] text-neutral-500 dark:text-neutral-400">
+              <p className="mt-2 text-[15px] text-muted-foreground dark:text-muted-foreground">
                 {collections.length === 0
                   ? "You haven't created any collections yet."
                   : `${collections.length} ${collections.length === 1 ? "collection" : "collections"}`}
@@ -48,8 +48,8 @@ export default async function CollectionsPage(): Promise<JSX.Element> {
           </div>
 
           {collections.length === 0 ? (
-            <div className="flex min-h-[200px] items-center justify-center rounded-2xl border border-dashed border-neutral-200 bg-neutral-50/50 dark:border-neutral-800 dark:bg-neutral-900/50">
-              <p className="text-[15px] text-neutral-400 dark:text-neutral-500">
+            <div className="flex min-h-[200px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/50 dark:border-border dark:bg-card/50">
+              <p className="text-[15px] text-muted-foreground dark:text-muted-foreground">
                 No collections yet
               </p>
             </div>

--- a/src/app/dashboard/_components/DeleteTagsForm.tsx
+++ b/src/app/dashboard/_components/DeleteTagsForm.tsx
@@ -76,7 +76,7 @@ export default function DeleteTagsForm({ tags }: PropTypes) {
       >
         {isLoading ||
           (isSubmitting && (
-            <div className="absolute left-0 top-0 z-10 h-full w-full bg-white bg-opacity-50">
+            <div className="absolute left-0 top-0 z-10 h-full w-full bg-card bg-opacity-50">
               <div className="absolute left-1/2 top-1/2 z-20 -translate-x-1/2 -translate-y-1/2">
                 <LoadingSpinner />
               </div>

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -51,7 +51,7 @@ export default async function FavoritesPage(): Promise<JSX.Element> {
     <>
       <SignedOut>
         <div className="container py-8">
-          <p className="text-center text-neutral-500">
+          <p className="text-center text-muted-foreground">
             Please sign in to view your favorites.
           </p>
         </div>
@@ -60,10 +60,10 @@ export default async function FavoritesPage(): Promise<JSX.Element> {
       <SignedIn>
         <div className="container py-8">
           <div className="mb-8">
-            <h1 className="text-3xl font-bold tracking-tight text-neutral-900 dark:text-white">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground dark:text-foreground">
               Your Favorites
             </h1>
-            <p className="mt-2 text-[15px] text-neutral-500 dark:text-neutral-400">
+            <p className="mt-2 text-[15px] text-muted-foreground dark:text-muted-foreground">
               {favorites.length === 0
                 ? "You haven't favorited any recipes yet."
                 : `${favorites.length} ${favorites.length === 1 ? "recipe" : "recipes"} saved`}
@@ -71,8 +71,8 @@ export default async function FavoritesPage(): Promise<JSX.Element> {
           </div>
 
           {favorites.length === 0 ? (
-            <div className="flex min-h-[200px] items-center justify-center rounded-2xl border border-dashed border-neutral-200 bg-neutral-50/50 dark:border-neutral-800 dark:bg-neutral-900/50">
-              <p className="text-[15px] text-neutral-400 dark:text-neutral-500">
+            <div className="flex min-h-[200px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/50 dark:border-border dark:bg-card/50">
+              <p className="text-[15px] text-muted-foreground dark:text-muted-foreground">
                 No favorites yet
               </p>
             </div>

--- a/src/app/kitchen-journey/badges/_components/AchievementBadge.tsx
+++ b/src/app/kitchen-journey/badges/_components/AchievementBadge.tsx
@@ -33,11 +33,11 @@ export default function AchievementBadge({
         />
       </div>
       <span
-        className={cn("text-sm font-medium", !isEarned && "text-slate-500")}
+        className={cn("text-sm font-medium", !isEarned && "text-muted-foreground")}
       >
         {name}
       </span>
-      <span className="text-center text-xs text-slate-500">{description}</span>
+      <span className="text-center text-xs text-muted-foreground">{description}</span>
     </div>
   );
 }

--- a/src/app/kitchen-journey/page.tsx
+++ b/src/app/kitchen-journey/page.tsx
@@ -247,7 +247,7 @@ const KitchenJourney = () => {
 
               <div className="pt-2">
                 <div className="mb-1 text-sm font-medium">Current Streak</div>
-                <div className="flex items-center gap-1 text-amber-600">
+                <div className="flex items-center gap-1 text-accent">
                   <Clock className="h-4 w-4" />
                   <span className="font-bold">
                     {userProgress.streakDays} days
@@ -263,7 +263,7 @@ const KitchenJourney = () => {
           <Card>
             <CardHeader className="pb-2">
               <CardTitle className="flex items-center gap-2 text-sm">
-                <Award className="h-5 w-5 text-amber-500" />
+                <Award className="h-5 w-5 text-accent" />
                 Next Achievements
               </CardTitle>
             </CardHeader>
@@ -274,7 +274,7 @@ const KitchenJourney = () => {
                     variant="outline"
                     className="flex h-8 w-8 items-center justify-center rounded-full p-0"
                   >
-                    <Star className="h-4 w-4 text-amber-500" />
+                    <Star className="h-4 w-4 text-accent" />
                   </Badge>
                   <span>Create 5 more recipes</span>
                 </li>
@@ -283,7 +283,7 @@ const KitchenJourney = () => {
                     variant="outline"
                     className="flex h-8 w-8 items-center justify-center rounded-full p-0"
                   >
-                    <Star className="h-4 w-4 text-amber-500" />
+                    <Star className="h-4 w-4 text-accent" />
                   </Badge>
                   <span>Maintain a 7-day streak</span>
                 </li>
@@ -361,7 +361,7 @@ const KitchenJourney = () => {
                   <div className="grid grid-cols-3 gap-3">
                     {/* Sample badges - dynamically generated based on actual badges */}
                     <div className="flex flex-col items-center text-center">
-                      <Badge className="mb-2 flex h-16 w-16 items-center justify-center rounded-full bg-amber-600 p-0 hover:bg-amber-700">
+                      <Badge className="mb-2 flex h-16 w-16 items-center justify-center rounded-full bg-accent/10 p-0 hover:bg-accent/10">
                         <Award className="h-8 w-8" />
                       </Badge>
                       <span className="text-sm font-medium">First Recipe</span>
@@ -371,7 +371,7 @@ const KitchenJourney = () => {
                     </div>
 
                     <div className="flex flex-col items-center text-center">
-                      <Badge className="mb-2 flex h-16 w-16 items-center justify-center rounded-full bg-amber-600 p-0 hover:bg-amber-700">
+                      <Badge className="mb-2 flex h-16 w-16 items-center justify-center rounded-full bg-accent/10 p-0 hover:bg-accent/10">
                         <Star className="h-8 w-8" />
                       </Badge>
                       <span className="text-sm font-medium">Level 2</span>
@@ -452,8 +452,8 @@ const KitchenJourney = () => {
 
           {/* Admin Panel */}
           {isAdmin && (
-            <Card className="overflow-hidden border-2 border-amber-200">
-              <CardHeader className="bg-amber-50">
+            <Card className="overflow-hidden border-2 border-accent/40">
+              <CardHeader className="bg-accent/10">
                 <CardTitle className="flex items-center gap-2">
                   <Settings className="h-5 w-5" />
                   Admin Controls

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "~/styles/globals.css";
 import "@uploadthing/react/styles.css";
-import { Inter as FontSans } from "next/font/google";
+import { Fraunces } from "next/font/google";
+import { GeistSans } from "geist/font/sans";
 
 import { ClerkProvider } from "@clerk/nextjs";
 import { NextSSRPlugin } from "@uploadthing/react/next-ssr-plugin";
@@ -13,9 +14,10 @@ import Footer from "./_components/Footer";
 import { Toaster } from "@/components/ui/sonner";
 import { env } from "~/env";
 
-const fontSans = FontSans({
+const fontDisplay = Fraunces({
   subsets: ["latin"],
-  variable: "--font-sans",
+  variable: "--font-display",
+  axes: ["SOFT", "WONK", "opsz"],
 });
 
 /**
@@ -63,13 +65,14 @@ export default function RootLayout({
       <html
         lang="en"
         style={{ colorScheme: "light" }}
-        className={`${fontSans.variable} light`}
+        className={`${GeistSans.variable} ${fontDisplay.variable} light`}
       >
         <NextSSRPlugin routerConfig={extractRouterConfig(ourFileRouter)} />
         <body
           className={cn(
-            "flex min-h-screen flex-col font-sans antialiased dark:bg-slate-950",
-            fontSans.variable,
+            "flex min-h-screen flex-col bg-background font-sans antialiased",
+            GeistSans.variable,
+            fontDisplay.variable,
           )}
         >
           <ThemeProvider attribute="class">

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -10,19 +10,10 @@ import { FavoritesSectionSkeleton } from "./_components/FavoritesSection";
 export default function Loading(): JSX.Element {
   return (
     <>
-      {/* Anonymous Homepage Loading */}
       <SignedOut>
         <div className="flex flex-col">
-          {/* Compact Hero Skeleton */}
-          <section className="relative flex min-h-[300px] w-full items-center justify-center overflow-hidden bg-neutral-50 px-4 py-16 dark:bg-neutral-900">
-            <div
-              className="absolute inset-0 opacity-[0.4] dark:opacity-[0.15]"
-              style={{
-                backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23000000' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-              }}
-            />
-            <div className="absolute left-1/4 top-0 h-[500px] w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-to-br from-amber-200/30 to-orange-100/20 blur-3xl dark:from-amber-500/10 dark:to-orange-500/5" />
-            <div className="absolute bottom-0 right-1/4 h-[400px] w-[400px] translate-x-1/2 translate-y-1/2 rounded-full bg-gradient-to-tl from-orange-200/25 to-amber-100/15 blur-3xl dark:from-orange-500/10 dark:to-amber-500/5" />
+          <section className="relative flex min-h-[300px] w-full items-center justify-center overflow-hidden border-b border-border bg-background px-4 py-16">
+            <div className="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-gradient-to-l from-herb-muted/40 to-transparent" />
 
             <div className="container relative z-10 mx-auto max-w-2xl text-center">
               <Skeleton className="mx-auto mb-4 h-10 w-3/4 sm:h-12" />
@@ -35,24 +26,22 @@ export default function Loading(): JSX.Element {
           </section>
 
           <div className="container space-y-16 py-12">
-            {/* Recipe Grid with Category Pills Skeleton */}
             <section>
               <div className="mb-8">
                 <Skeleton className="mb-1 h-6 w-48" />
                 <Skeleton className="mb-5 h-4 w-64" />
                 <div className="flex flex-wrap gap-2">
                   {Array.from({ length: 6 }, (_, i) => (
-                    <Skeleton key={i} className="h-9 w-20 rounded-full" />
+                    <Skeleton key={i} className="h-9 w-20 rounded-md" />
                   ))}
                 </div>
               </div>
               <RecipeGridSkeleton count={9} />
             </section>
 
-            {/* Featured Recipe Spotlight Skeleton */}
-            <section className="overflow-hidden rounded-2xl border border-neutral-200/60 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+            <section className="overflow-hidden rounded-2xl border border-border bg-card">
               <div className="grid grid-cols-1 md:grid-cols-2">
-                <Skeleton className="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800 md:aspect-auto md:min-h-[320px]" />
+                <Skeleton className="aspect-[4/3] bg-muted md:aspect-auto md:min-h-[320px]" />
                 <div className="flex flex-col justify-center p-8 md:p-10">
                   <Skeleton className="mb-3 h-3 w-32" />
                   <Skeleton className="mb-3 h-8 w-3/4 md:h-9" />
@@ -62,48 +51,30 @@ export default function Loading(): JSX.Element {
               </div>
             </section>
 
-            {/* Social Proof Strip Skeleton */}
-            <div className="flex items-center justify-center gap-12 border-y border-neutral-100 py-8 dark:border-neutral-800 md:gap-20">
-              {Array.from({ length: 3 }, (_, i) => (
-                <div key={i} className="flex items-center gap-3">
-                  <Skeleton className="h-10 w-10 rounded-xl" />
-                  <div>
-                    <Skeleton className="mb-1 h-4 w-12" />
-                    <Skeleton className="h-3 w-20" />
-                  </div>
-                </div>
-              ))}
+            <div className="rounded-2xl border border-border bg-muted/50 px-8 py-10">
+              <Skeleton className="mx-auto mb-2 h-5 w-80 max-w-full" />
+              <Skeleton className="mx-auto h-4 w-56 max-w-full" />
             </div>
 
-            {/* Footer CTA Skeleton */}
-            <section className="relative overflow-hidden rounded-2xl bg-neutral-900 px-8 py-12 text-center">
-              <div className="absolute inset-0 bg-gradient-to-br from-neutral-800/50 via-transparent to-neutral-950/30" />
-              <div
-                className="absolute inset-0 opacity-[0.03]"
-                style={{
-                  backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-                }}
-              />
+            <section className="relative overflow-hidden rounded-2xl bg-primary px-8 py-12 text-center">
               <div className="relative z-10">
-                <Skeleton className="mx-auto mb-3 h-8 w-80 max-w-full md:h-9" />
-                <Skeleton className="mx-auto mb-8 h-4 w-64 max-w-full" />
-                <Skeleton className="mx-auto h-12 w-32 rounded-xl bg-white/20" />
+                <Skeleton className="mx-auto mb-3 h-8 w-80 max-w-full bg-primary-foreground/20 md:h-9" />
+                <Skeleton className="mx-auto mb-8 h-4 w-64 max-w-full bg-primary-foreground/20" />
+                <Skeleton className="mx-auto h-12 w-32 rounded-xl bg-card/20" />
               </div>
             </section>
           </div>
         </div>
       </SignedOut>
 
-      {/* Logged-In Homepage Loading */}
       <SignedIn>
         <div className="container space-y-6 py-6">
-          {/* Greeting Bar Skeleton */}
           <div className="flex items-center justify-between py-6">
             <div>
               <Skeleton className="mb-1 h-8 w-64 md:h-9" />
               <Skeleton className="h-4 w-48" />
             </div>
-            <div className="flex items-center gap-3 rounded-2xl border border-neutral-200 bg-white px-4 py-2.5 dark:border-neutral-800 dark:bg-neutral-900">
+            <div className="flex items-center gap-3 rounded-2xl border border-border bg-card px-4 py-2.5">
               <Skeleton className="h-10 w-10 rounded-full" />
               <div className="hidden sm:block">
                 <Skeleton className="mb-1 h-4 w-12" />
@@ -112,17 +83,15 @@ export default function Loading(): JSX.Element {
             </div>
           </div>
 
-          {/* Favorites Section Skeleton */}
           <FavoritesSectionSkeleton />
 
-          {/* Recipe Grid with Category Pills Skeleton */}
           <section>
             <div className="mb-8">
               <Skeleton className="mb-1 h-6 w-48" />
               <Skeleton className="mb-5 h-4 w-64" />
               <div className="flex flex-wrap gap-2">
                 {Array.from({ length: 6 }, (_, i) => (
-                  <Skeleton key={i} className="h-9 w-20 rounded-full" />
+                  <Skeleton key={i} className="h-9 w-20 rounded-md" />
                 ))}
               </div>
             </div>

--- a/src/app/new-recipe/_components/CreateRecipeForm.tsx
+++ b/src/app/new-recipe/_components/CreateRecipeForm.tsx
@@ -93,7 +93,7 @@ export default function CreateRecipeForm() {
           >
             {isLoading ||
               (isSubmitting && (
-                <div className="absolute left-0 top-0 z-10 h-full w-full bg-white bg-opacity-50">
+                <div className="absolute left-0 top-0 z-10 h-full w-full bg-card bg-opacity-50">
                   <div className="absolute left-1/2 top-1/2 z-20 -translate-x-1/2 -translate-y-1/2">
                     <LoadingSpinner />
                   </div>

--- a/src/app/new-recipe/_components/wizard/WizardPublish.tsx
+++ b/src/app/new-recipe/_components/wizard/WizardPublish.tsx
@@ -173,7 +173,7 @@ export function WizardPublish({ onPublish }: WizardPublishProps): JSX.Element {
                   <div
                     className={`flex h-6 w-6 items-center justify-center rounded-full ${
                       isPassed
-                        ? "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400"
+                        ? "bg-green-100 text-herb dark:bg-green-900 dark:text-herb"
                         : check.severity === "error"
                           ? "bg-red-100 text-red-600 dark:bg-red-900 dark:text-red-400"
                           : "bg-yellow-100 text-yellow-600 dark:bg-yellow-900 dark:text-yellow-400"

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -9,13 +9,11 @@ export default function NotFound(): JSX.Element {
   return (
     <div className="container flex min-h-[60vh] flex-col items-center justify-center py-16">
       <div className="text-center">
-        <h1 className="text-6xl font-bold text-neutral-900 dark:text-white">
-          404
-        </h1>
-        <h2 className="mt-4 text-2xl font-semibold text-neutral-700 dark:text-neutral-300">
+        <h1 className="font-display text-6xl font-bold text-foreground">404</h1>
+        <h2 className="mt-4 font-display text-2xl font-semibold text-foreground">
           Page Not Found
         </h2>
-        <p className="mt-2 text-[15px] text-neutral-500 dark:text-neutral-400">
+        <p className="mt-2 text-[15px] text-muted-foreground">
           The page you&apos;re looking for doesn&apos;t exist.
         </p>
         <div className="mt-8">

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { SignInButton, SignedIn, SignedOut } from "@clerk/nextjs";
-import { Check, Sparkles, Zap } from "lucide-react";
+import { Check, Sparkles } from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -29,27 +29,17 @@ export default function PricingPage(): JSX.Element {
   return (
     <div className="flex min-h-screen flex-col">
       {/* Hero Section */}
-      <section className="relative overflow-hidden border-b border-slate-200 bg-neutral-50 px-4 py-16 dark:border-slate-800 dark:bg-neutral-900">
-        {/* Subtle background pattern */}
-        <div
-          className="absolute inset-0 opacity-[0.4] dark:opacity-[0.15]"
-          style={{
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23000000' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-          }}
-        />
-
-        {/* Gradient orbs */}
-        <div className="absolute left-1/4 top-0 h-[400px] w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-to-br from-amber-200/30 to-orange-100/20 blur-3xl dark:from-amber-500/10 dark:to-orange-500/5" />
-        <div className="absolute bottom-0 right-1/4 h-[300px] w-[300px] translate-x-1/2 translate-y-1/2 rounded-full bg-gradient-to-tl from-orange-200/25 to-amber-100/15 blur-3xl dark:from-orange-500/10 dark:to-amber-500/5" />
+      <section className="relative overflow-hidden border-b border-border bg-background px-4 py-16">
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-gradient-to-l from-herb-muted/50 to-transparent" />
 
         <div className="container relative z-10 mx-auto max-w-4xl text-center">
           <Badge variant="secondary" className="mb-4 text-sm font-medium">
             Currently Free • Premium Coming Soon
           </Badge>
-          <h1 className="mb-4 text-balance text-4xl font-semibold tracking-tight text-neutral-900 dark:text-white sm:text-5xl lg:text-6xl">
+          <h1 className="mb-4 text-balance text-4xl font-semibold tracking-tight font-display text-foreground sm:text-5xl lg:text-6xl">
             Simple, Transparent Pricing
           </h1>
-          <p className="mx-auto mb-8 max-w-2xl text-base leading-relaxed text-neutral-600 dark:text-neutral-400 sm:text-lg">
+          <p className="mx-auto mb-8 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
             Start cooking with our free tier today. We&apos;re building
             something thoughtful for the kitchen—you&apos;re early, and we
             appreciate it.
@@ -61,15 +51,15 @@ export default function PricingPage(): JSX.Element {
       <section className="container mx-auto px-4 py-16">
         <div className="mx-auto grid max-w-5xl gap-8 md:grid-cols-2">
           {/* Free Tier */}
-          <Card className="relative flex flex-col border-2 border-slate-200 dark:border-slate-800">
+          <Card className="relative flex flex-col border-2 border-border">
             <CardHeader>
               <div className="mb-2 flex items-center gap-2">
-                <Zap className="h-5 w-5 text-amber-500" />
+                <span aria-hidden className="inline-block h-2.5 w-2.5 rounded-sm bg-accent" />
                 <CardTitle className="text-2xl">Free</CardTitle>
               </div>
               <div className="flex items-baseline gap-2">
                 <span className="text-4xl font-bold">$0</span>
-                <span className="text-slate-500 dark:text-slate-400">
+                <span className="text-muted-foreground">
                   /month
                 </span>
               </div>
@@ -80,38 +70,38 @@ export default function PricingPage(): JSX.Element {
             <CardContent className="flex-grow space-y-4">
               <ul className="space-y-3">
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     Browse all recipes
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     Save & like recipes
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     Basic personalization (diet, dislikes)
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     Light gamification (XP, streaks)
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     Limited collections
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     Limited meal planning
                   </span>
                 </li>
@@ -137,10 +127,10 @@ export default function PricingPage(): JSX.Element {
           </Card>
 
           {/* Hyper+ Tier */}
-          <Card className="relative flex flex-col border-2 border-amber-500/50 bg-gradient-to-br from-amber-50/50 to-orange-50/30 dark:border-amber-500/30 dark:from-amber-950/20 dark:to-orange-950/10">
+          <Card className="relative flex flex-col border-2 border-accent/40 bg-gradient-to-br from-accent/5 to-herb-muted/40">
             <CardHeader>
               <div className="mb-2 flex items-center gap-2">
-                <Sparkles className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+                <Sparkles className="h-5 w-5 text-accent" />
                 <CardTitle className="text-2xl">Hyper+</CardTitle>
                 <Badge variant="secondary" className="ml-auto text-xs">
                   Coming Soon
@@ -148,11 +138,11 @@ export default function PricingPage(): JSX.Element {
               </div>
               <div className="flex items-baseline gap-2">
                 <span className="text-4xl font-bold">$6</span>
-                <span className="text-slate-500 dark:text-slate-400">
+                <span className="text-muted-foreground">
                   /month
                 </span>
               </div>
-              <CardDescription className="mt-2 text-sm italic text-slate-600 dark:text-slate-400">
+              <CardDescription className="mt-2 text-sm italic text-muted-foreground">
                 *Pricing not final—subject to change
               </CardDescription>
               <CardDescription className="mt-2 text-base">
@@ -162,45 +152,45 @@ export default function PricingPage(): JSX.Element {
             <CardContent className="flex-grow space-y-4">
               <ul className="space-y-3">
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     Everything in Free
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     <span className="font-medium">Unlimited</span> meal planning
                     & collections
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     Smart shopping lists
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     AI recipe customization (faster, swaps, vegan, macros)
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     &quot;Cook with what I have&quot; pantry mode
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-foreground/80">
                     Advanced recommendations
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-slate-400" />
-                  <span className="text-sm text-slate-500 dark:text-slate-400">
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-herb" />
+                  <span className="text-sm text-muted-foreground">
                     Skill trees & progress analytics
                     <Badge variant="outline" className="ml-2 text-xs">
                       Planned
@@ -213,7 +203,7 @@ export default function PricingPage(): JSX.Element {
               <Button
                 size="lg"
                 variant="outline"
-                className="w-full rounded-xl border-amber-500/50 bg-amber-50/50 text-amber-900 hover:bg-amber-100/70 dark:border-amber-500/30 dark:bg-amber-950/30 dark:text-amber-100 dark:hover:bg-amber-950/50"
+                className="w-full rounded-xl border-accent/40 bg-accent/5 text-accent hover:bg-accent/10"
                 disabled
               >
                 Join Hyper+ waitlist
@@ -224,121 +214,121 @@ export default function PricingPage(): JSX.Element {
       </section>
 
       {/* Feature Comparison */}
-      <section className="border-t border-slate-200 bg-slate-50/50 px-4 py-16 dark:border-slate-800 dark:bg-slate-950/50">
+      <section className="border-t border-border bg-muted/40 px-4 py-16">
         <div className="container mx-auto max-w-4xl">
-          <h2 className="mb-8 text-center text-3xl font-semibold tracking-tight">
+          <h2 className="mb-8 text-center font-display text-3xl font-semibold tracking-tight">
             Feature Comparison
           </h2>
-          <div className="overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+          <div className="overflow-hidden rounded-lg border border-border bg-card">
             <table className="w-full">
               <thead>
-                <tr className="border-b border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-950">
-                  <th className="px-6 py-4 text-left text-sm font-semibold text-slate-900 dark:text-slate-50">
+                <tr className="border-b border-border bg-muted/50">
+                  <th className="px-6 py-4 text-left text-sm font-semibold text-foreground">
                     Feature
                   </th>
-                  <th className="px-6 py-4 text-center text-sm font-semibold text-slate-900 dark:text-slate-50">
+                  <th className="px-6 py-4 text-center text-sm font-semibold text-foreground">
                     Free
                   </th>
-                  <th className="px-6 py-4 text-center text-sm font-semibold text-slate-900 dark:text-slate-50">
+                  <th className="px-6 py-4 text-center text-sm font-semibold text-foreground">
                     Hyper+
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+              <tbody className="divide-y divide-border">
                 <tr>
-                  <td className="px-6 py-4 text-sm text-slate-700 dark:text-slate-300">
+                  <td className="px-6 py-4 text-sm text-foreground/80">
                     Recipe browsing
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 text-sm text-slate-700 dark:text-slate-300">
+                  <td className="px-6 py-4 text-sm text-foreground/80">
                     Save & favorite recipes
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 text-sm text-slate-700 dark:text-slate-300">
+                  <td className="px-6 py-4 text-sm text-foreground/80">
                     Collections
                   </td>
-                  <td className="px-6 py-4 text-center text-sm text-slate-500 dark:text-slate-400">
+                  <td className="px-6 py-4 text-center text-sm text-muted-foreground">
                     Limited
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 text-sm text-slate-700 dark:text-slate-300">
+                  <td className="px-6 py-4 text-sm text-foreground/80">
                     Meal planning
                   </td>
-                  <td className="px-6 py-4 text-center text-sm text-slate-500 dark:text-slate-400">
+                  <td className="px-6 py-4 text-center text-sm text-muted-foreground">
                     Limited
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 text-sm text-slate-700 dark:text-slate-300">
+                  <td className="px-6 py-4 text-sm text-foreground/80">
                     Smart shopping lists
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <span className="text-slate-400">—</span>
+                    <span className="text-muted-foreground">—</span>
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 text-sm text-slate-700 dark:text-slate-300">
+                  <td className="px-6 py-4 text-sm text-foreground/80">
                     AI recipe customization
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <span className="text-slate-400">—</span>
+                    <span className="text-muted-foreground">—</span>
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 text-sm text-slate-700 dark:text-slate-300">
+                  <td className="px-6 py-4 text-sm text-foreground/80">
                     Pantry mode
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <span className="text-slate-400">—</span>
+                    <span className="text-muted-foreground">—</span>
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 text-sm text-slate-700 dark:text-slate-300">
+                  <td className="px-6 py-4 text-sm text-foreground/80">
                     Advanced recommendations
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <span className="text-slate-400">—</span>
+                    <span className="text-muted-foreground">—</span>
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" />
+                    <Check className="mx-auto h-5 w-5 text-herb" />
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 text-sm text-slate-700 dark:text-slate-300">
+                  <td className="px-6 py-4 text-sm text-foreground/80">
                     Skill trees & analytics
                   </td>
                   <td className="px-6 py-4 text-center">
-                    <span className="text-slate-400">—</span>
+                    <span className="text-muted-foreground">—</span>
                   </td>
                   <td className="px-6 py-4 text-center">
                     <Badge variant="outline" className="text-xs">
@@ -355,18 +345,18 @@ export default function PricingPage(): JSX.Element {
       {/* FAQ Section */}
       <section className="container mx-auto px-4 py-16">
         <div className="mx-auto max-w-3xl">
-          <h2 className="mb-8 text-center text-3xl font-semibold tracking-tight">
+          <h2 className="mb-8 text-center font-display text-3xl font-semibold tracking-tight">
             Frequently Asked Questions
           </h2>
           <Accordion type="single" collapsible className="space-y-4">
             <AccordionItem
               value="premium-live"
-              className="rounded-lg border border-slate-200 bg-white px-6 dark:border-slate-800 dark:bg-slate-900"
+              className="rounded-lg border border-border bg-card px-6"
             >
               <AccordionTrigger className="text-left">
                 Is Hyper+ available yet?
               </AccordionTrigger>
-              <AccordionContent className="text-slate-600 dark:text-slate-400">
+              <AccordionContent className="text-muted-foreground">
                 Not yet! We&apos;re still building the premium features. Hyper+
                 is coming soon, and we&apos;ll let you know as soon as it&apos;s
                 ready. Early users will get priority access when we launch.
@@ -374,12 +364,12 @@ export default function PricingPage(): JSX.Element {
             </AccordionItem>
             <AccordionItem
               value="free-forever"
-              className="rounded-lg border border-slate-200 bg-white px-6 dark:border-slate-800 dark:bg-slate-900"
+              className="rounded-lg border border-border bg-card px-6"
             >
               <AccordionTrigger className="text-left">
                 Will the free tier always be available?
               </AccordionTrigger>
-              <AccordionContent className="text-slate-600 dark:text-slate-400">
+              <AccordionContent className="text-muted-foreground">
                 Yes! The free tier will always remain available. We believe
                 everyone should have access to great recipes and cooking tools.
                 Hyper+ is about unlocking additional power features, not
@@ -388,12 +378,12 @@ export default function PricingPage(): JSX.Element {
             </AccordionItem>
             <AccordionItem
               value="early-access"
-              className="rounded-lg border border-slate-200 bg-white px-6 dark:border-slate-800 dark:bg-slate-900"
+              className="rounded-lg border border-border bg-card px-6"
             >
               <AccordionTrigger className="text-left">
                 How do I get early access to Hyper+?
               </AccordionTrigger>
-              <AccordionContent className="text-slate-600 dark:text-slate-400">
+              <AccordionContent className="text-muted-foreground">
                 Join the waitlist when it becomes available! Early users and
                 active community members will be the first to know when Hyper+
                 launches. We&apos;re building this with you in mind.
@@ -401,12 +391,12 @@ export default function PricingPage(): JSX.Element {
             </AccordionItem>
             <AccordionItem
               value="pricing-final"
-              className="rounded-lg border border-slate-200 bg-white px-6 dark:border-slate-800 dark:bg-slate-900"
+              className="rounded-lg border border-border bg-card px-6"
             >
               <AccordionTrigger className="text-left">
                 Is the $6/month pricing final?
               </AccordionTrigger>
-              <AccordionContent className="text-slate-600 dark:text-slate-400">
+              <AccordionContent className="text-muted-foreground">
                 The pricing shown is a placeholder and subject to change.
                 We&apos;re still finalizing the exact features and pricing
                 structure. We&apos;ll announce the final pricing before launch,
@@ -418,18 +408,18 @@ export default function PricingPage(): JSX.Element {
       </section>
 
       {/* Final CTA */}
-      <section className="border-t border-slate-200 bg-neutral-900 px-4 py-16 dark:border-slate-800">
+      <section className="border-t border-border bg-primary px-4 py-16">
         <div className="container mx-auto max-w-2xl text-center">
-          <h2 className="mb-4 text-3xl font-semibold tracking-tight text-white">
+          <h2 className="mb-4 font-display text-3xl font-semibold tracking-tight text-primary-foreground">
             Ready to start cooking?
           </h2>
-          <p className="mb-8 text-neutral-400">
+          <p className="mb-8 text-primary-foreground/70">
             Join thousands of home cooks discovering new recipes every day
           </p>
           <SignedOut>
             <Button
               size="lg"
-              className="h-12 rounded-xl bg-white px-8 text-[15px] font-medium text-neutral-900 shadow-lg transition-all hover:bg-neutral-100 hover:shadow-xl"
+              className="h-12 px-8 text-[15px] font-medium"
               asChild
             >
               <SignInButton mode="modal">Sign up free</SignInButton>
@@ -439,7 +429,7 @@ export default function PricingPage(): JSX.Element {
             <Button
               size="lg"
               variant="outline"
-              className="h-12 rounded-xl border-white/20 bg-transparent px-8 text-[15px] font-medium text-white transition-all hover:bg-white/10"
+              className="h-12 border-primary-foreground/20 bg-transparent px-8 text-[15px] font-medium text-primary-foreground hover:bg-primary-foreground/10"
               asChild
             >
               <Link href="/">Continue to app</Link>

--- a/src/app/recipe/[slug]/_components/AddToCollectionButton.tsx
+++ b/src/app/recipe/[slug]/_components/AddToCollectionButton.tsx
@@ -156,28 +156,28 @@ export function AddToCollectionButton({
                           }
                         }}
                         disabled={isPending || isInCollection}
-                        className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-neutral-800"
+                        className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-muted"
                       >
                         <div className="flex-1">
                           <div className="font-medium">{collection.title}</div>
                           {collection.description && (
-                            <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                            <div className="text-xs text-muted-foreground dark:text-muted-foreground">
                               {collection.description}
                             </div>
                           )}
                         </div>
                         {isInCollection && (
-                          <Check className="h-4 w-4 text-green-600 dark:text-green-400" />
+                          <Check className="h-4 w-4 text-herb dark:text-herb" />
                         )}
                       </button>
                     );
                   })}
                 </div>
               )}
-              <div className="border-t border-neutral-200 pt-2 dark:border-neutral-800">
+              <div className="border-t border-border pt-2 dark:border-border">
                 <button
                   type="button"
-                  className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                  className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-muted dark:hover:bg-muted"
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/src/app/recipe/[slug]/_components/AssignTagsForm.tsx
+++ b/src/app/recipe/[slug]/_components/AssignTagsForm.tsx
@@ -60,7 +60,7 @@ export default function AssignTagsForm({
       >
         {isLoading ||
           (isSubmitting && (
-            <div className="absolute left-0 top-0 z-10 h-full w-full bg-white bg-opacity-50">
+            <div className="absolute left-0 top-0 z-10 h-full w-full bg-card bg-opacity-50">
               <div className="absolute left-1/2 top-1/2 z-20 -translate-x-1/2 -translate-y-1/2">
                 <LoadingSpinner />
               </div>

--- a/src/app/recipe/[slug]/_components/CookModeOverlay.tsx
+++ b/src/app/recipe/[slug]/_components/CookModeOverlay.tsx
@@ -120,7 +120,7 @@ export function CookModeOverlay({
       <div className="fixed inset-0 z-50 flex flex-col bg-background">
         <div className="h-1 bg-muted">
           <div
-            className="h-full bg-primary transition-all duration-300"
+            className="h-full bg-herb transition-all duration-300"
             style={{ width: `${progress}%` }}
           />
         </div>
@@ -153,7 +153,7 @@ export function CookModeOverlay({
               className={cn(
                 "mb-6 inline-flex h-16 w-16 items-center justify-center rounded-full text-2xl font-bold",
                 isCurrentStepCompleted
-                  ? "bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400"
+                  ? "bg-green-100 text-herb dark:bg-green-900/30 dark:text-herb"
                   : "bg-primary/10 text-primary"
               )}
             >

--- a/src/app/recipe/[slug]/_components/CookingHistory.tsx
+++ b/src/app/recipe/[slug]/_components/CookingHistory.tsx
@@ -43,7 +43,7 @@ type Cook = {
 
 function StarRating({ rating }: { rating: number }) {
   return (
-    <div className="flex text-amber-400">
+    <div className="flex text-accent">
       {[1, 2, 3, 4, 5].map((value) => {
         const difference = value - rating;
         if (difference <= 0) {
@@ -51,7 +51,7 @@ function StarRating({ rating }: { rating: number }) {
         } else if (difference > 0 && difference < 1) {
           return <StarHalf key={value} size={16} className="fill-current" />;
         } else {
-          return <Star key={value} size={16} className="text-slate-200" />;
+          return <Star key={value} size={16} className="text-muted" />;
         }
       })}
     </div>
@@ -127,11 +127,11 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
 
   const renderStar = (starNumber: number, currentRating: number) => {
     if (starNumber <= Math.floor(currentRating)) {
-      return <Star className="h-8 w-8 fill-amber-400 text-amber-400" />;
+      return <Star className="h-8 w-8 fill-accent text-accent" />;
     } else if (starNumber - 0.5 === currentRating) {
-      return <StarHalf className="h-8 w-8 fill-amber-400 text-amber-400" />;
+      return <StarHalf className="h-8 w-8 fill-accent text-accent" />;
     } else {
-      return <Star className="h-8 w-8 text-slate-200" />;
+      return <Star className="h-8 w-8 text-muted" />;
     }
   };
 
@@ -189,7 +189,7 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
                   {cooks.map((cook, i) => (
                     <div
                       key={i}
-                      className="flex flex-col space-y-1 border-b border-slate-100 pb-2 last:border-0"
+                      className="flex flex-col space-y-1 border-b border-border pb-2 last:border-0"
                     >
                       <div className="flex items-center justify-between">
                         <span className="text-sm text-muted-foreground">
@@ -237,7 +237,7 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
                     onClick={(e) => handleStarClick(star, e)}
                     onMouseMove={(e) => handleStarHover(star, e)}
                     onMouseLeave={() => setHoveredRating(0)}
-                    className="p-1 hover:text-amber-400"
+                    className="p-1 hover:text-accent"
                   >
                     {renderStar(star, hoveredRating || editingRating)}
                   </button>
@@ -252,7 +252,7 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
             {selectedCook?.notes && (
               <div className="space-y-2">
                 <label className="text-sm font-medium">Notes</label>
-                <p className="whitespace-pre-wrap rounded-md border border-slate-200 p-3 text-sm text-slate-700 dark:border-slate-800 dark:text-slate-300">
+                <p className="whitespace-pre-wrap rounded-md border border-border p-3 text-sm text-foreground/80 dark:border-border dark:text-muted-foreground">
                   {selectedCook.notes}
                 </p>
               </div>

--- a/src/app/recipe/[slug]/_components/EditRecipeForm.tsx
+++ b/src/app/recipe/[slug]/_components/EditRecipeForm.tsx
@@ -75,7 +75,7 @@ const EditRecipeForm: React.FC<EditRecipeFormProps> = ({
       >
         {isLoading ||
           (isSubmitting && (
-            <div className="absolute left-0 top-0 z-10 h-full w-full bg-white bg-opacity-50">
+            <div className="absolute left-0 top-0 z-10 h-full w-full bg-card bg-opacity-50">
               <div className="absolute left-1/2 top-1/2 z-20 -translate-x-1/2 -translate-y-1/2">
                 <LoadingSpinner />
               </div>

--- a/src/app/recipe/[slug]/_components/FavoriteButton.tsx
+++ b/src/app/recipe/[slug]/_components/FavoriteButton.tsx
@@ -63,7 +63,7 @@ export function FavoriteButton({ recipeId }: FavoriteButtonProps): JSX.Element |
     >
       <Star
         className={`h-5 w-5 transition-all active:-translate-y-1 ${
-          isFavorite ? "fill-amber-400" : ""
+          isFavorite ? "fill-accent" : ""
         } ${isLoading ? "opacity-50" : ""}`}
       />
     </Button>

--- a/src/app/recipe/[slug]/_components/FullRecipePage.tsx
+++ b/src/app/recipe/[slug]/_components/FullRecipePage.tsx
@@ -299,7 +299,7 @@ export function FullRecipePageClient({
   return (
     <>
       {!recipe.published && (
-        <div className="mb-8 flex items-center justify-between rounded-md border border-yellow-400 bg-yellow-100 p-4 font-semibold text-yellow-800 dark:border-yellow-600 dark:bg-yellow-900/30 dark:text-yellow-200">
+        <div className="mb-8 flex items-center justify-between rounded-md border border-accent/40 bg-accent/10 p-4 font-semibold text-accent">
           <div>
             <AlertTriangle
               size={16}

--- a/src/app/recipe/[slug]/_components/IngredientsForm.tsx
+++ b/src/app/recipe/[slug]/_components/IngredientsForm.tsx
@@ -101,7 +101,7 @@ export default function IngredientsForm({
         >
           {isLoading ||
             (isSubmitting && (
-              <div className="absolute left-0 top-0 z-10 h-full w-full bg-white bg-opacity-50">
+              <div className="absolute left-0 top-0 z-10 h-full w-full bg-card bg-opacity-50">
                 <div className="absolute left-1/2 top-1/2 z-20 -translate-x-1/2 -translate-y-1/2">
                   <LoadingSpinner />
                 </div>

--- a/src/app/recipe/[slug]/_components/RecipeHeader.tsx
+++ b/src/app/recipe/[slug]/_components/RecipeHeader.tsx
@@ -92,7 +92,7 @@ export function RecipeHeader({
     <header className="mb-6 space-y-4">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-2">
-          <h1 className="text-3xl font-semibold tracking-tight lg:text-4xl">
+          <h1 className="font-display text-3xl font-semibold tracking-tight lg:text-4xl">
             {recipe.name}
           </h1>
           {recipe.description && (

--- a/src/app/recipe/[slug]/_components/StepCard.tsx
+++ b/src/app/recipe/[slug]/_components/StepCard.tsx
@@ -83,9 +83,9 @@ export function StepCard({
     <div
       className={cn(
         "group relative rounded-lg border p-4 transition-all",
-        isActive && "border-primary bg-primary/5 ring-1 ring-primary",
-        isCompleted && "border-muted bg-muted/30",
-        !isActive && !isCompleted && "border-border hover:border-primary/50",
+        isActive && "border-accent bg-accent/5 ring-1 ring-accent/40",
+        isCompleted && "border-herb/30 bg-herb-muted/50",
+        !isActive && !isCompleted && "border-border hover:border-accent/40",
         onClick && "cursor-pointer"
       )}
       onClick={onClick}
@@ -93,9 +93,9 @@ export function StepCard({
       <div className="flex gap-4">
         <div
           className={cn(
-            "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-semibold",
-            isActive && "bg-primary text-primary-foreground",
-            isCompleted && "bg-muted-foreground/20 text-muted-foreground",
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-sm font-semibold",
+            isActive && "bg-accent text-accent-foreground",
+            isCompleted && "bg-herb text-herb-foreground",
             !isActive && !isCompleted && "bg-muted text-muted-foreground"
           )}
         >

--- a/src/app/recipe/[slug]/_components/StepsEditor.tsx
+++ b/src/app/recipe/[slug]/_components/StepsEditor.tsx
@@ -73,9 +73,9 @@ export default function StepsEditor({
   if (!isLoaded) {
     return (
       <div className="prose-headings:font-title font-default prose prose-lg max-w-full animate-pulse dark:prose-invert">
-        <div className="h-4 w-3/4 rounded bg-slate-200" />
-        <div className="mt-2 h-4 w-full rounded bg-slate-200" />
-        <div className="mt-2 h-4 w-5/6 rounded bg-slate-200" />
+        <div className="h-4 w-3/4 rounded bg-muted" />
+        <div className="mt-2 h-4 w-full rounded bg-muted" />
+        <div className="mt-2 h-4 w-5/6 rounded bg-muted" />
       </div>
     );
   }

--- a/src/app/recipe/[slug]/loading.tsx
+++ b/src/app/recipe/[slug]/loading.tsx
@@ -69,7 +69,7 @@ export default function RecipeLoading() {
 
           {/* Steps Card */}
           <Card>
-            <CardHeader className="mb-4 border-b border-slate-200">
+            <CardHeader className="mb-4 border-b border-border">
               <CardTitle as="h2" className="text-3xl">
                 Steps
               </CardTitle>

--- a/src/app/recipe/[slug]/rate/page.tsx
+++ b/src/app/recipe/[slug]/rate/page.tsx
@@ -46,11 +46,11 @@ export default function RateRecipePage({
 
   const renderStar = (starNumber: number, currentRating: number) => {
     if (starNumber <= Math.floor(currentRating)) {
-      return <Star className="h-8 w-8 fill-amber-400 text-amber-400" />;
+      return <Star className="h-8 w-8 fill-accent text-accent" />;
     } else if (starNumber - 0.5 === currentRating) {
-      return <StarHalf className="h-8 w-8 fill-amber-400 text-amber-400" />;
+      return <StarHalf className="h-8 w-8 fill-accent text-accent" />;
     } else {
-      return <Star className="h-8 w-8 text-slate-200" />;
+      return <Star className="h-8 w-8 text-muted" />;
     }
   };
 
@@ -104,7 +104,7 @@ export default function RateRecipePage({
                   onClick={(e) => handleStarClick(star, e)}
                   onMouseMove={(e) => handleStarHover(star, e)}
                   onMouseLeave={() => setHoveredRating(0)}
-                  className="p-1 hover:text-amber-400"
+                  className="p-1 hover:text-accent"
                 >
                   {renderStar(star, hoveredRating || rating)}
                 </button>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:border-slate-800 dark:bg-slate-950",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:border-border dark:bg-background",
         className
       )}
       {...props}
@@ -91,7 +91,7 @@ const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    className={cn("text-sm text-primary-foreground0 dark:text-muted-foreground", className)}
     {...props}
   />
 ))

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,27 +1,30 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "~/lib/utils"
+import { cn } from "~/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-300",
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80",
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
         secondary:
-          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
-          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80",
-        outline: "text-slate-950 dark:text-slate-50",
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "border-border text-foreground",
+        accent:
+          "border-transparent bg-accent text-accent-foreground hover:bg-accent/80",
+        herb: "border-transparent bg-herb-muted text-herb hover:bg-herb-muted/80",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -30,7 +33,7 @@ export interface BadgeProps
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
     <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,21 +5,21 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "~/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300",
+  "inline-flex select-none items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default:
-          "bg-slate-900 text-slate-50 hover:bg-slate-900/90 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/90",
+          "bg-accent text-accent-foreground hover:bg-accent/90 shadow-soft",
         destructive:
-          "bg-red-500 text-slate-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-slate-200 bg-white hover:bg-slate-100 hover:text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50",
+          "border border-border bg-card hover:bg-muted hover:text-foreground",
         secondary:
-          "bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
-        ghost:
-          "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50",
-        link: "text-slate-900 underline-offset-4 hover:underline dark:text-slate-50",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-muted hover:text-foreground",
+        link: "text-foreground underline-offset-4 hover:underline hover:text-accent",
+        ink: "bg-primary text-primary-foreground hover:bg-primary/90",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      "rounded-lg border border-border bg-card text-card-foreground shadow-soft",
       className,
     )}
     {...props}
@@ -38,7 +38,7 @@ const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
     <Component
       ref={ref}
       className={cn(
-        "text-2xl font-semibold leading-none tracking-tight",
+        "font-display text-2xl font-semibold leading-none tracking-tight",
         className,
       )}
       {...props}
@@ -54,7 +54,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-slate-200 border-slate-900 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-900 data-[state=checked]:text-slate-50 dark:border-slate-800 dark:border-slate-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300 dark:data-[state=checked]:bg-slate-50 dark:data-[state=checked]:text-slate-900",
+      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:border-border dark:border-primary-foreground dark:ring-offset-background dark:focus-visible:ring-ring dark:data-[state=checked]:bg-primary dark:data-[state=checked]:text-foreground",
       className
     )}
     {...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -15,7 +15,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-white text-slate-950 dark:bg-slate-950 dark:text-slate-50",
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-card text-foreground dark:bg-background dark:text-primary-foreground",
       className,
     )}
     {...props}
@@ -29,7 +29,7 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-slate-500 dark:[&_[cmdk-group-heading]]:text-slate-400 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-primary-foreground0 dark:[&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>
@@ -46,7 +46,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-slate-500 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-slate-400",
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-primary-foreground0 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-muted-foreground",
         className,
       )}
       {...props}
@@ -89,7 +89,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "overflow-hidden p-1 text-slate-950 dark:text-slate-50 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-slate-500 dark:[&_[cmdk-group-heading]]:text-slate-400",
+      "overflow-hidden p-1 text-foreground dark:text-primary-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-primary-foreground0 dark:[&_[cmdk-group-heading]]:text-muted-foreground",
       className,
     )}
     {...props}
@@ -104,7 +104,7 @@ const CommandSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 h-px bg-slate-200 dark:bg-slate-800", className)}
+    className={cn("-mx-1 h-px bg-border dark:bg-muted", className)}
     {...props}
   />
 ));
@@ -117,7 +117,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-slate-100 aria-selected:text-slate-900 data-[disabled='true']:pointer-events-none data-[disabled='true']:opacity-50 dark:aria-selected:bg-slate-800 dark:aria-selected:text-slate-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-muted aria-selected:text-foreground data-[disabled='true']:pointer-events-none data-[disabled='true']:opacity-50 dark:aria-selected:bg-muted dark:aria-selected:text-primary-foreground",
       className,
     )}
     {...props}
@@ -133,7 +133,7 @@ const CommandShortcut = ({
   return (
     <span
       className={cn(
-        "ml-auto text-xs tracking-widest text-slate-500 dark:text-slate-400",
+        "ml-auto text-xs tracking-widest text-primary-foreground0 dark:text-muted-foreground",
         className,
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-slate-800 dark:bg-slate-950 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-border dark:bg-background sm:rounded-lg",
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-slate-100 data-[state=open]:text-slate-500 dark:ring-offset-slate-950 dark:focus:ring-slate-300 dark:data-[state=open]:bg-slate-800 dark:data-[state=open]:text-slate-400">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-muted data-[state=open]:text-primary-foreground0 dark:ring-offset-background dark:focus:ring-ring dark:data-[state=open]:bg-muted dark:data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -102,7 +102,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    className={cn("text-sm text-primary-foreground0 dark:text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -43,12 +43,12 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-950",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border border-border bg-card dark:border-border dark:bg-background",
         className
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-slate-100 dark:bg-slate-800" />
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted dark:bg-muted" />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>
@@ -98,7 +98,7 @@ const DrawerDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    className={cn("text-sm text-primary-foreground0 dark:text-muted-foreground", className)}
     {...props}
   />
 ))

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-slate-100 data-[state=open]:bg-slate-100 dark:focus:bg-slate-800 dark:data-[state=open]:bg-slate-800",
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-muted data-[state=open]:bg-muted dark:focus:bg-muted dark:data-[state=open]:bg-muted",
       inset && "pl-8",
       className
     )}
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-slate-950 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-card p-1 text-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-border dark:bg-background dark:text-primary-foreground",
       className
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-slate-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-card p-1 text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-border dark:bg-background dark:text-primary-foreground",
         className
       )}
       {...props}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-muted dark:focus:text-primary-foreground",
       inset && "pl-8",
       className
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-muted dark:focus:text-primary-foreground",
       className
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-muted dark:focus:text-primary-foreground",
       className
     )}
     {...props}
@@ -162,7 +162,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-slate-100 dark:bg-slate-800", className)}
+    className={cn("-mx-1 my-1 h-px bg-muted dark:bg-muted", className)}
     {...props}
   />
 ))

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -95,7 +95,7 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
-      className={cn(error && "text-red-500 dark:text-red-900", className)}
+      className={cn(error && "text-destructive dark:text-destructive", className)}
       htmlFor={formItemId}
       {...props}
     />
@@ -135,7 +135,7 @@ const FormDescription = React.forwardRef<
     <p
       ref={ref}
       id={formDescriptionId}
-      className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+      className={cn("text-sm text-primary-foreground0 dark:text-muted-foreground", className)}
       {...props}
     />
   )
@@ -157,7 +157,7 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
-      className={cn("text-sm font-medium text-red-500 dark:text-red-900", className)}
+      className={cn("text-sm font-medium text-destructive dark:text-destructive", className)}
       {...props}
     >
       {body}

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -18,7 +18,7 @@ const HoverCardContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-md border border-slate-200 bg-white p-4 text-slate-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      "z-50 w-64 rounded-md border border-border bg-card p-4 text-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-border dark:bg-background dark:text-primary-foreground",
       className
     )}
     {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          "flex h-10 w-full rounded-md border border-border bg-card px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-primary-foreground0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-border dark:bg-background dark:ring-offset-background dark:placeholder:text-muted-foreground dark:focus-visible:ring-ring",
           className,
         )}
         ref={ref}

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -46,7 +46,7 @@ const multiSelectVariants = cva(
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         inverted: "inverted",
         themed:
-          "rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+          "rounded-lg border border-border bg-card text-foreground shadow-sm dark:border-border dark:bg-background dark:text-primary-foreground",
       },
     },
     defaultVariants: {

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border border-slate-200 bg-white p-4 text-slate-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+        "z-50 w-72 rounded-md border border-border bg-card p-4 text-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-border dark:bg-background dark:text-primary-foreground",
         className
       )}
       {...props}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -12,13 +12,13 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      "relative h-4 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800",
+      "relative h-4 w-full overflow-hidden rounded-full bg-muted dark:bg-muted",
       className,
     )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-slate-900 transition-all dark:bg-slate-50"
+      className="h-full w-full flex-1 bg-primary transition-all dark:bg-primary"
       style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300",
+      "flex h-10 w-full items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm ring-offset-background placeholder:text-primary-foreground0 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-border dark:bg-background dark:ring-offset-background dark:placeholder:text-muted-foreground dark:focus:ring-ring",
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-card text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-border dark:bg-background dark:text-primary-foreground",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-muted dark:focus:text-primary-foreground",
       className
     )}
     {...props}
@@ -140,7 +140,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-slate-100 dark:bg-slate-800", className)}
+    className={cn("-mx-1 my-1 h-px bg-muted dark:bg-muted", className)}
     {...props}
   />
 ))

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -18,7 +18,7 @@ const Separator = React.forwardRef<
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-slate-200 dark:bg-slate-800",
+        "shrink-0 bg-border dark:bg-muted",
         orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
         className
       )}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-white p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 dark:bg-slate-950",
+  "fixed z-50 gap-4 bg-card p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 dark:bg-background",
   {
     variants: {
       side: {
@@ -65,7 +65,7 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-slate-100 dark:ring-offset-slate-950 dark:focus:ring-slate-300 dark:data-[state=open]:bg-slate-800">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-muted dark:ring-offset-background dark:focus:ring-ring dark:data-[state=open]:bg-muted">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
@@ -109,7 +109,7 @@ const SheetTitle = React.forwardRef<
   <SheetPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold text-slate-950 dark:text-slate-50",
+      "text-lg font-semibold text-foreground dark:text-primary-foreground",
       className,
     )}
     {...props}
@@ -123,7 +123,7 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    className={cn("text-sm text-primary-foreground0 dark:text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-slate-100 dark:bg-slate-800", className)}
+      className={cn("animate-pulse rounded-md bg-muted dark:bg-muted", className)}
       {...props}
     />
   )

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -15,12 +15,12 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-white group-[.toaster]:text-slate-950 group-[.toaster]:border-slate-200 group-[.toaster]:shadow-lg dark:group-[.toaster]:bg-slate-950 dark:group-[.toaster]:text-slate-50 dark:group-[.toaster]:border-slate-800",
-          description: "group-[.toast]:text-slate-500 dark:group-[.toast]:text-slate-400",
+            "group toast group-[.toaster]:bg-card group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg dark:group-[.toaster]:bg-background dark:group-[.toaster]:text-primary-foreground dark:group-[.toaster]:border-border",
+          description: "group-[.toast]:text-primary-foreground0 dark:group-[.toast]:text-muted-foreground",
           actionButton:
-            "group-[.toast]:bg-slate-900 group-[.toast]:text-slate-50 dark:group-[.toast]:bg-slate-50 dark:group-[.toast]:text-slate-900",
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground dark:group-[.toast]:bg-primary dark:group-[.toast]:text-foreground",
           cancelButton:
-            "group-[.toast]:bg-slate-100 group-[.toast]:text-slate-500 dark:group-[.toast]:bg-slate-800 dark:group-[.toast]:text-slate-400",
+            "group-[.toast]:bg-muted group-[.toast]:text-primary-foreground0 dark:group-[.toast]:bg-muted dark:group-[.toast]:text-muted-foreground",
         },
       }}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-slate-100 p-1 text-slate-500 dark:bg-slate-800 dark:text-slate-400",
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-primary-foreground0 dark:bg-muted dark:text-muted-foreground",
       className
     )}
     {...props}
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-slate-950 data-[state=active]:shadow-sm dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300 dark:data-[state=active]:bg-slate-950 dark:data-[state=active]:text-slate-50",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:ring-offset-background dark:focus-visible:ring-ring dark:data-[state=active]:bg-background dark:data-[state=active]:text-primary-foreground",
       className
     )}
     {...props}
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300",
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:ring-offset-background dark:focus-visible:ring-ring",
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          "flex min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm ring-offset-background placeholder:text-primary-foreground0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-border dark:bg-background dark:ring-offset-background dark:placeholder:text-muted-foreground dark:focus-visible:ring-ring",
           className,
         )}
         ref={ref}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -7,13 +7,13 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "~/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-white transition-colors hover:bg-slate-100 hover:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-slate-100 data-[state=on]:text-slate-900 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2 dark:ring-offset-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-400 dark:focus-visible:ring-slate-300 dark:data-[state=on]:bg-slate-800 dark:data-[state=on]:text-slate-50",
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-primary-foreground0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-muted data-[state=on]:text-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2 dark:ring-offset-background dark:hover:bg-muted dark:hover:text-muted-foreground dark:focus-visible:ring-ring dark:data-[state=on]:bg-muted dark:data-[state=on]:text-primary-foreground",
   {
     variants: {
       variant: {
         default: "bg-transparent",
         outline:
-          "border border-slate-200 bg-transparent hover:bg-slate-100 hover:text-slate-900 dark:border-slate-800 dark:hover:bg-slate-800 dark:hover:text-slate-50",
+          "border border-border bg-transparent hover:bg-muted hover:text-foreground dark:border-border dark:hover:bg-muted dark:hover:text-primary-foreground",
       },
       size: {
         default: "h-10 px-3 min-w-10",

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-950 shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin] dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      "z-50 overflow-hidden rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin] dark:border-border dark:bg-background dark:text-primary-foreground",
       className
     )}
     {...props}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,72 +14,89 @@
   .text-balance {
     text-wrap: balance;
   }
+
+  .animate-rise {
+    animation: rise 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .animate-fade-in {
+    animation: fade-in 0.6s ease-out both;
+  }
 }
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
+    /* Cool stone paper — not warm cream */
+    --background: 40 10% 97%;
+    --foreground: 30 8% 12%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card: 40 12% 99%;
+    --card-foreground: 30 8% 12%;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
+    --popover: 40 12% 99%;
+    --popover-foreground: 30 8% 12%;
 
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
+    /* Ink primary */
+    --primary: 30 10% 14%;
+    --primary-foreground: 40 15% 98%;
 
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
+    --secondary: 35 8% 92%;
+    --secondary-foreground: 30 8% 18%;
 
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
+    --muted: 35 8% 93%;
+    --muted-foreground: 30 5% 42%;
 
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
+    /* Chili / paprika brand accent */
+    --accent: 12 78% 48%;
+    --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 5.9% 10%;
+    --border: 35 8% 86%;
+    --input: 35 8% 86%;
+    --ring: 12 78% 48%;
 
-    --radius: 0.625rem;
+    /* Herb / sage secondary */
+    --herb: 145 18% 38%;
+    --herb-foreground: 0 0% 100%;
+    --herb-muted: 145 20% 94%;
 
-    --amber-accent: 25 95% 53%;
-    --amber-accent-muted: 30 80% 96%;
+    --radius: 0.5rem;
   }
 
   .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
+    --background: 30 8% 8%;
+    --foreground: 40 10% 96%;
 
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
+    --card: 30 8% 11%;
+    --card-foreground: 40 10% 96%;
 
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 30 8% 11%;
+    --popover-foreground: 40 10% 96%;
 
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
+    --primary: 40 12% 96%;
+    --primary-foreground: 30 10% 12%;
 
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
+    --secondary: 30 6% 16%;
+    --secondary-foreground: 40 10% 94%;
 
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
+    --muted: 30 6% 16%;
+    --muted-foreground: 35 6% 62%;
 
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
+    --accent: 12 72% 52%;
+    --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 0 62% 42%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --border: 30 6% 18%;
+    --input: 30 6% 18%;
+    --ring: 12 72% 52%;
+
+    --herb: 145 22% 52%;
+    --herb-foreground: 30 8% 8%;
+    --herb-muted: 145 14% 16%;
   }
 
   * {
@@ -91,18 +108,18 @@
   }
 
   h1 {
-    @apply scroll-m-20 text-4xl font-semibold tracking-tight lg:text-5xl;
-    letter-spacing: -0.025em;
-  }
-
-  h2 {
-    @apply scroll-m-20 text-2xl font-semibold tracking-tight first:mt-0;
+    @apply scroll-m-20 font-display text-4xl font-semibold tracking-tight lg:text-5xl;
     letter-spacing: -0.02em;
   }
 
-  h3 {
-    @apply scroll-m-20 text-xl font-semibold tracking-tight;
+  h2 {
+    @apply scroll-m-20 font-display text-2xl font-semibold tracking-tight first:mt-0;
     letter-spacing: -0.015em;
+  }
+
+  h3 {
+    @apply scroll-m-20 font-display text-xl font-semibold tracking-tight;
+    letter-spacing: -0.01em;
   }
 
   h4 {
@@ -114,7 +131,7 @@
   }
 
   blockquote {
-    @apply mt-6 border-l-2 pl-6 italic;
+    @apply mt-6 border-l-2 border-accent/40 pl-6 italic;
   }
 
   ul {
@@ -123,5 +140,25 @@
 
   li {
     @apply leading-relaxed;
+  }
+}
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -55,9 +55,24 @@ const config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        herb: {
+          DEFAULT: "hsl(var(--herb))",
+          foreground: "hsl(var(--herb-foreground))",
+          muted: "hsl(var(--herb-muted))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
-        sans: ["var(--font-sans)", ...fontFamily.sans],
+        sans: ["var(--font-geist-sans)", ...fontFamily.sans],
+        display: ["var(--font-display)", ...fontFamily.serif],
+      },
+      boxShadow: {
+        soft: "0 1px 2px hsl(30 8% 12% / 0.04), 0 4px 12px hsl(30 8% 12% / 0.06)",
+        lift: "0 4px 20px hsl(30 8% 12% / 0.08)",
       },
       keyframes: {
         "accordion-down": {
@@ -76,10 +91,26 @@ const config = {
             height: "0",
           },
         },
+        rise: {
+          from: {
+            opacity: "0",
+            transform: "translateY(12px)",
+          },
+          to: {
+            opacity: "1",
+            transform: "translateY(0)",
+          },
+        },
+        "fade-in": {
+          from: { opacity: "0" },
+          to: { opacity: "1" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        rise: "rise 0.7s cubic-bezier(0.22, 1, 0.36, 1) both",
+        "fade-in": "fade-in 0.6s ease-out both",
       },
     },
   },


### PR DESCRIPTION
## Summary
- Rebuild the design system around cool stone paper, Fraunces display + Geist Sans, chili accent, and herb secondary tokens
- Restyle shadcn primitives, nav/footer, and cascade semantic tokens across marketing, home, recipe detail, and secondary routes
- Remove Inter, dual slate/neutral palettes, amber-orb heroes, and yellow Zap brand treatment

## Test plan
- [ ] Anonymous homepage: hero, adapt preview, why-better, CTA — no amber orbs/cross-pattern
- [ ] Logged-in homepage: section titles, cards, spotlight, filters
- [ ] Recipe detail: header, ingredients, steps (active/complete), cook mode progress, mobile sticky bar
- [ ] Pricing page: cards, comparison table, FAQ, final CTA
- [ ] Spot-check favorites, collections, kitchen journey, new-recipe wizard
- [ ] Confirm brand mark + “Hyper Recipes” wordmark in nav/footer


Made with [Cursor](https://cursor.com)