### PR TITLE
feat: wire hero image upload into recipe Quick Edit

### DIFF
--- a/src/app/recipe/[slug]/_components/FullRecipeSheet.tsx
+++ b/src/app/recipe/[slug]/_components/FullRecipeSheet.tsx
@@ -19,6 +19,7 @@ import {
 import AssignTagsForm from "./AssignTagsForm";
 import IngredientsForm from "./IngredientsForm";
 import EditRecipeForm from "./EditRecipeForm";
+import UploadImageDialog from "./ImageDialogue";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default async function FullRecipeSheet({
@@ -41,6 +42,15 @@ export default async function FullRecipeSheet({
           <SheetTitle>Edit Recipe</SheetTitle>
         </SheetHeader>
         <div className="flex flex-col gap-8 pb-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>Hero Image</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <UploadImageDialog recipeId={recipeId} />
+            </CardContent>
+          </Card>
+
           <Suspense
             fallback={
               <Card>


### PR DESCRIPTION
## Summary
- Expose the existing `UploadImageDialog` in the admin Quick Edit sheet so hero images can be uploaded or selected for a recipe
- Fixes the orphaned upload UI that previously had no entry point on the recipe page

## Test plan
- [ ] Sign in as an admin and open a recipe page
- [ ] Open Quick Edit and confirm the Hero Image card appears
- [ ] Upload a new image and confirm it becomes the recipe hero
- [ ] Select an existing gallery image and confirm it updates the hero
- [ ] Confirm non-admin users do not see Quick Edit


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Hero Image” section to recipe sheets.
  * Users can now upload or update a recipe’s hero image directly from the recipe sheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->