### PR TITLE
feat: redesign recipe page with hero photo and clearer cook flow

### DIFF
--- a/src/app/recipe/[slug]/_components/AdaptThisRecipe.tsx
+++ b/src/app/recipe/[slug]/_components/AdaptThisRecipe.tsx
@@ -2,18 +2,16 @@
 
 import { useState } from "react";
 import { useUser } from "@clerk/nextjs";
-import { Minus, Plus, ArrowRightLeft } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChevronDown, Minus, Plus, SlidersHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerDescription,
-} from "@/components/ui/drawer";
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { AuthGateModal } from "./AuthGateModal";
+import { cn } from "~/lib/utils";
 
 type DifficultyLevel = "EASY" | "MEDIUM" | "HARD";
 
@@ -35,37 +33,25 @@ interface AdaptThisRecipeProps {
   difficulty?: DifficultyLevel;
   onDifficultyChange?: (difficulty: DifficultyLevel) => void;
   hasV2Data?: boolean;
-  swaps?: IngredientSwap[];
+  /** When true, starts collapsed (default). Pass false for drawer contexts. */
+  defaultCollapsed?: boolean;
+  /** Skip the collapsible chrome when already inside a drawer. */
+  embedded?: boolean;
 }
 
 type TimeOption = "quick" | "standard" | "slow";
 type DifficultyOption = "beginner" | "confident";
 
 /**
- * Formats a swap quantity for display.
- * @param quantity - Numeric quantity
- * @param unit - Unit string
- * @returns Formatted quantity string
- */
-function formatSwapQuantity(quantity: number, unit: string): string {
-  const formatted =
-    quantity % 1 === 0
-      ? quantity.toString()
-      : quantity.toFixed(2).replace(/\.?0+$/, "");
-  return unit ? `${formatted} ${unit}` : formatted;
-}
-
-/**
- * Adapt this recipe card - the key differentiator feature.
- * Controls for servings, time, swaps, and difficulty.
- * Anonymous users see controls but are gated on interaction.
- * Now supports v2 difficulty levels (EASY/MEDIUM/HARD).
+ * Collapsed-by-default adapt controls for servings, time, and difficulty.
+ * Swaps live near cooking tips instead. Auth-gated for anonymous users.
  * @param servings - Current servings state
  * @param onServingsChange - Callback when servings change
  * @param difficulty - Current difficulty level (v2)
  * @param onDifficultyChange - Callback when difficulty changes (v2)
  * @param hasV2Data - Whether this recipe has v2 difficulty variations
- * @param swaps - Ingredient substitution suggestions
+ * @param defaultCollapsed - Whether the panel starts collapsed
+ * @param embedded - Skip collapsible chrome when already inside a drawer
  */
 export function AdaptThisRecipe({
   servings,
@@ -73,11 +59,12 @@ export function AdaptThisRecipe({
   difficulty = "MEDIUM",
   onDifficultyChange,
   hasV2Data = false,
-  swaps = [],
+  defaultCollapsed = true,
+  embedded = false,
 }: AdaptThisRecipeProps): JSX.Element {
   const { isSignedIn, isLoaded } = useUser();
   const [showAuthGate, setShowAuthGate] = useState(false);
-  const [showSwapsDrawer, setShowSwapsDrawer] = useState(false);
+  const [isOpen, setIsOpen] = useState(!defaultCollapsed);
   const [timeOption, setTimeOption] = useState<TimeOption>("standard");
   const [difficultyOption, setDifficultyOption] =
     useState<DifficultyOption>("confident");
@@ -126,200 +113,160 @@ export function AdaptThisRecipe({
     });
   };
 
-  const handleShowSwaps = (): void => {
-    requireAuth(() => {
-      setShowSwapsDrawer(true);
-    });
-  };
+  const controls = (
+    <div className="space-y-5">
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Servings</label>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={handleServingsDecrease}
+            disabled={servings <= 1}
+          >
+            <Minus className="h-4 w-4" />
+          </Button>
+          <span className="w-8 text-center font-semibold">{servings}</span>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={handleServingsIncrease}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
 
-  return (
-    <>
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-lg">Adapt this recipe</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-5">
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Servings</label>
-            <div className="flex items-center gap-3">
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-8 w-8"
-                onClick={handleServingsDecrease}
-                disabled={servings <= 1}
-              >
-                <Minus className="h-4 w-4" />
-              </Button>
-              <span className="w-8 text-center font-semibold">{servings}</span>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-8 w-8"
-                onClick={handleServingsIncrease}
-              >
-                <Plus className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Time</label>
+        <ToggleGroup
+          type="single"
+          value={timeOption}
+          onValueChange={handleTimeChange}
+          className="justify-start"
+        >
+          <ToggleGroupItem value="quick" aria-label="Quick" className="px-4">
+            Quick
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            value="standard"
+            aria-label="Standard"
+            className="px-4"
+          >
+            Standard
+          </ToggleGroupItem>
+          <ToggleGroupItem value="slow" aria-label="Slow" className="px-4">
+            Slow
+          </ToggleGroupItem>
+        </ToggleGroup>
+        <p className="text-xs text-muted-foreground">Adjust steps and pacing</p>
+      </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Time</label>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Difficulty</label>
+        {hasV2Data ? (
+          <>
             <ToggleGroup
               type="single"
-              value={timeOption}
-              onValueChange={handleTimeChange}
+              value={difficulty}
+              onValueChange={handleV2DifficultyChange}
               className="justify-start"
             >
-              <ToggleGroupItem
-                value="quick"
-                aria-label="Quick"
-                className="px-4"
-              >
-                Quick
+              <ToggleGroupItem value="EASY" aria-label="Easy" className="px-4">
+                Easy
               </ToggleGroupItem>
               <ToggleGroupItem
-                value="standard"
-                aria-label="Standard"
+                value="MEDIUM"
+                aria-label="Medium"
                 className="px-4"
               >
-                Standard
+                Medium
               </ToggleGroupItem>
-              <ToggleGroupItem value="slow" aria-label="Slow" className="px-4">
-                Slow
+              <ToggleGroupItem value="HARD" aria-label="Hard" className="px-4">
+                Hard
               </ToggleGroupItem>
             </ToggleGroup>
             <p className="text-xs text-muted-foreground">
-              Adjust steps and pacing
+              Recipe adapts to your skill level
             </p>
-          </div>
-
-          <div>
-            <Button
-              variant="outline"
-              className="w-full justify-start"
-              onClick={handleShowSwaps}
+          </>
+        ) : (
+          <>
+            <ToggleGroup
+              type="single"
+              value={difficultyOption}
+              onValueChange={handleDifficultyChange}
+              className="justify-start"
             >
-              <ArrowRightLeft className="mr-2 h-4 w-4" />
-              See swaps
-              {swaps.length > 0 ? ` (${swaps.length})` : ""}
-            </Button>
-          </div>
+              <ToggleGroupItem
+                value="beginner"
+                aria-label="Beginner"
+                className="px-4"
+              >
+                Beginner
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="confident"
+                aria-label="Confident"
+                className="px-4"
+              >
+                Confident
+              </ToggleGroupItem>
+            </ToggleGroup>
+            <p className="text-xs text-muted-foreground">
+              More guidance vs. fewer prompts
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Difficulty</label>
-            {hasV2Data ? (
-              <>
-                <ToggleGroup
-                  type="single"
-                  value={difficulty}
-                  onValueChange={handleV2DifficultyChange}
-                  className="justify-start"
-                >
-                  <ToggleGroupItem
-                    value="EASY"
-                    aria-label="Easy"
-                    className="px-4"
-                  >
-                    Easy
-                  </ToggleGroupItem>
-                  <ToggleGroupItem
-                    value="MEDIUM"
-                    aria-label="Medium"
-                    className="px-4"
-                  >
-                    Medium
-                  </ToggleGroupItem>
-                  <ToggleGroupItem
-                    value="HARD"
-                    aria-label="Hard"
-                    className="px-4"
-                  >
-                    Hard
-                  </ToggleGroupItem>
-                </ToggleGroup>
-                <p className="text-xs text-muted-foreground">
-                  Recipe adapts to your skill level
-                </p>
-              </>
-            ) : (
-              <>
-                <ToggleGroup
-                  type="single"
-                  value={difficultyOption}
-                  onValueChange={handleDifficultyChange}
-                  className="justify-start"
-                >
-                  <ToggleGroupItem
-                    value="beginner"
-                    aria-label="Beginner"
-                    className="px-4"
-                  >
-                    Beginner
-                  </ToggleGroupItem>
-                  <ToggleGroupItem
-                    value="confident"
-                    aria-label="Confident"
-                    className="px-4"
-                  >
-                    Confident
-                  </ToggleGroupItem>
-                </ToggleGroup>
-                <p className="text-xs text-muted-foreground">
-                  More guidance vs. fewer prompts
-                </p>
-              </>
-            )}
+  return (
+    <>
+      {embedded ? (
+        controls
+      ) : (
+        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+          <div className="overflow-hidden rounded-xl border border-dashed border-border/80 bg-muted/30">
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/50"
+              >
+                <span className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden />
+                  <span className="font-medium text-foreground/80">
+                    Adapt this recipe
+                  </span>
+                  <span className="hidden text-xs sm:inline">
+                    · servings, time, difficulty
+                  </span>
+                </span>
+                <ChevronDown
+                  className={cn(
+                    "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+                    isOpen && "rotate-180",
+                  )}
+                />
+              </button>
+            </CollapsibleTrigger>
+
+            <CollapsibleContent>
+              <div className="border-t border-border/60 px-4 py-4">
+                {controls}
+              </div>
+            </CollapsibleContent>
           </div>
-        </CardContent>
-      </Card>
+        </Collapsible>
+      )}
 
       <AuthGateModal
         isOpen={showAuthGate}
         onClose={() => setShowAuthGate(false)}
       />
-
-      <Drawer open={showSwapsDrawer} onOpenChange={setShowSwapsDrawer}>
-        <DrawerContent>
-          <DrawerHeader>
-            <DrawerTitle>Ingredient Swaps</DrawerTitle>
-            <DrawerDescription>
-              Suggested alternatives for this recipe
-            </DrawerDescription>
-          </DrawerHeader>
-          <div className="max-h-[60vh] space-y-4 overflow-y-auto p-4 pb-8">
-            {swaps.length === 0 ? (
-              <p className="text-center text-sm text-muted-foreground">
-                No swap suggestions available for this recipe yet.
-              </p>
-            ) : (
-              swaps.map((swap) => (
-                <div
-                  key={swap.originalIngredientId}
-                  className="rounded-lg border p-3"
-                >
-                  <p className="text-sm font-medium">{swap.originalName}</p>
-                  <ul className="mt-2 space-y-1.5">
-                    {swap.substitutes.map((sub) => (
-                      <li
-                        key={sub.ingredientId}
-                        className="text-sm text-muted-foreground"
-                      >
-                        <span className="font-medium text-foreground">
-                          {sub.ingredientName}
-                        </span>
-                        {" — "}
-                        {formatSwapQuantity(sub.quantity, sub.unit)}
-                        {sub.notes ? ` (${sub.notes})` : ""}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))
-            )}
-          </div>
-        </DrawerContent>
-      </Drawer>
     </>
   );
 }

--- a/src/app/recipe/[slug]/_components/AuthGateModal.tsx
+++ b/src/app/recipe/[slug]/_components/AuthGateModal.tsx
@@ -46,7 +46,7 @@ export function AuthGateModal({
         <DialogHeader>
           <DialogTitle>Unlock smart recipe controls</DialogTitle>
           <DialogDescription>
-            Adjust time, servings, and ingredient swaps with a free account.
+            Adjust time, servings, and difficulty with a free account.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="flex-col gap-2 sm:flex-col">

--- a/src/app/recipe/[slug]/_components/CookModeOverlay.tsx
+++ b/src/app/recipe/[slug]/_components/CookModeOverlay.tsx
@@ -1,14 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { X, ChevronLeft, ChevronRight, Check, UtensilsCrossed } from "lucide-react";
+import { X, ChevronLeft, ChevronRight, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
 import { cn } from "~/lib/utils";
 
 interface IngredientItem {
@@ -28,13 +22,12 @@ interface CookModeOverlayProps {
 }
 
 /**
- * Full-screen cook mode overlay for focused cooking.
- * Shows one step at a time with navigation controls.
+ * Full-screen cook mode with always-visible ingredients and one step at a time.
+ * Desktop: ingredients sidebar + step stage. Mobile: ingredients strip above step.
  * @param isOpen - Whether cook mode is active
  * @param onClose - Callback to exit cook mode
  * @param steps - Array of step strings
  * @param ingredients - Array of ingredients for quick reference
- * @param recipeName - Name of the recipe
  */
 export function CookModeOverlay({
   isOpen,
@@ -44,7 +37,6 @@ export function CookModeOverlay({
 }: CookModeOverlayProps): JSX.Element | null {
   const [currentStep, setCurrentStep] = useState(0);
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
-  const [showIngredients, setShowIngredients] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -113,125 +105,119 @@ export function CookModeOverlay({
   const isFirstStep = currentStep === 0;
   const isLastStep = currentStep === steps.length - 1;
   const isCurrentStepCompleted = completedSteps.has(currentStep);
-  const progress = ((currentStep + 1) / steps.length) * 100;
+  const progress =
+    steps.length > 0 ? ((currentStep + 1) / steps.length) * 100 : 0;
+
+  const ingredientsList = (
+    <ul className="space-y-2.5">
+      {ingredients.length === 0 ? (
+        <li className="text-sm text-muted-foreground">
+          Ingredients unavailable.
+        </li>
+      ) : (
+        ingredients.map(({ ingredient, quantity, ingredientId }) => (
+          <li key={ingredientId} className="text-sm leading-snug">
+            <span className="font-semibold tabular-nums">{quantity}</span>{" "}
+            <span className="text-foreground/85">{ingredient.name}</span>
+          </li>
+        ))
+      )}
+    </ul>
+  );
 
   return (
-    <>
-      <div className="fixed inset-0 z-50 flex flex-col bg-background">
-        <div className="h-1 bg-muted">
-          <div
-            className="h-full bg-herb transition-all duration-300"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
-
-        <header className="flex items-center justify-between border-b px-4 py-3">
-          <div className="flex items-center gap-3">
-            <span className="text-sm font-medium text-muted-foreground">
-              Step {currentStep + 1} of {steps.length}
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowIngredients(true)}
-            >
-              <UtensilsCrossed className="mr-1.5 h-4 w-4" />
-              Ingredients
-            </Button>
-            <Button variant="ghost" size="sm" onClick={onClose}>
-              <X className="mr-1.5 h-4 w-4" />
-              Exit Cook Mode
-            </Button>
-          </div>
-        </header>
-
-        <main className="flex flex-1 flex-col items-center justify-center px-6 py-8">
-          <div className="max-w-2xl text-center">
-            <div
-              className={cn(
-                "mb-6 inline-flex h-16 w-16 items-center justify-center rounded-full text-2xl font-bold",
-                isCurrentStepCompleted
-                  ? "bg-green-100 text-herb dark:bg-green-900/30 dark:text-herb"
-                  : "bg-primary/10 text-primary"
-              )}
-            >
-              {isCurrentStepCompleted ? (
-                <Check className="h-8 w-8" />
-              ) : (
-                currentStep + 1
-              )}
-            </div>
-            <p
-              className={cn(
-                "text-2xl leading-relaxed md:text-3xl",
-                isCurrentStepCompleted && "text-muted-foreground"
-              )}
-            >
-              {steps[currentStep]}
-            </p>
-          </div>
-        </main>
-
-        <footer className="border-t px-4 py-4">
-          <div className="mx-auto flex max-w-2xl items-center justify-between gap-4">
-            <Button
-              variant="outline"
-              onClick={handleBack}
-              disabled={isFirstStep}
-              className="w-24"
-            >
-              <ChevronLeft className="mr-1 h-4 w-4" />
-              Back
-            </Button>
-
-            <Button
-              onClick={handleMarkDone}
-              disabled={isCurrentStepCompleted}
-              className="flex-1 max-w-xs"
-            >
-              <Check className="mr-1.5 h-4 w-4" />
-              Done
-            </Button>
-
-            <Button
-              variant="outline"
-              onClick={handleNext}
-              disabled={isLastStep}
-              className="w-24"
-            >
-              Next
-              <ChevronRight className="ml-1 h-4 w-4" />
-            </Button>
-          </div>
-        </footer>
+    <div className="fixed inset-0 z-50 flex flex-col bg-background">
+      <div className="h-1 bg-muted">
+        <div
+          className="h-full bg-herb transition-all duration-300"
+          style={{ width: `${progress}%` }}
+        />
       </div>
 
-      <Drawer open={showIngredients} onOpenChange={setShowIngredients}>
-        <DrawerContent>
-          <DrawerHeader>
-            <DrawerTitle>Ingredients</DrawerTitle>
-          </DrawerHeader>
-          <div className="max-h-[60vh] overflow-y-auto px-4 pb-8">
-            {ingredients.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                Ingredients unavailable.
-              </p>
-            ) : (
-              <ul className="space-y-2">
-                {ingredients.map(({ ingredient, quantity, ingredientId }) => (
-                  <li key={ingredientId} className="text-sm">
-                    <span className="font-semibold">{quantity}</span>{" "}
-                    {ingredient.name}
-                  </li>
-                ))}
-              </ul>
-            )}
+      <header className="flex items-center justify-between border-b border-border/70 px-4 py-3">
+        <span className="text-sm font-medium text-muted-foreground">
+          Step {currentStep + 1} of {steps.length}
+        </span>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          <X className="mr-1.5 h-4 w-4" />
+          Exit
+        </Button>
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+        <aside className="shrink-0 border-b border-border/70 bg-card/50 lg:w-80 lg:border-b-0 lg:border-r lg:overflow-y-auto">
+          <div className="px-4 py-3 lg:px-5 lg:py-5">
+            <h2 className="mb-3 font-display text-sm font-semibold uppercase tracking-[0.12em] text-muted-foreground lg:text-base lg:normal-case lg:tracking-tight lg:text-foreground">
+              Ingredients
+            </h2>
+            <div className="max-h-36 overflow-y-auto pr-1 lg:max-h-none">
+              {ingredientsList}
+            </div>
           </div>
-        </DrawerContent>
-      </Drawer>
-    </>
+        </aside>
+
+        <main className="flex min-h-0 flex-1 flex-col">
+          <div className="flex flex-1 flex-col items-center justify-center overflow-y-auto px-6 py-8">
+            <div className="max-w-2xl text-center animate-rise">
+              <div
+                className={cn(
+                  "mb-6 inline-flex h-14 w-14 items-center justify-center rounded-full font-display text-xl font-semibold",
+                  isCurrentStepCompleted
+                    ? "bg-herb-muted text-herb"
+                    : "bg-accent/10 text-accent",
+                )}
+              >
+                {isCurrentStepCompleted ? (
+                  <Check className="h-7 w-7" />
+                ) : (
+                  currentStep + 1
+                )}
+              </div>
+              <p
+                className={cn(
+                  "font-display text-2xl leading-snug tracking-tight md:text-3xl md:leading-snug",
+                  isCurrentStepCompleted && "text-muted-foreground",
+                )}
+              >
+                {steps[currentStep]}
+              </p>
+            </div>
+          </div>
+
+          <footer className="border-t border-border/70 px-4 py-4">
+            <div className="mx-auto flex max-w-2xl items-center justify-between gap-3">
+              <Button
+                variant="outline"
+                onClick={handleBack}
+                disabled={isFirstStep}
+                className="w-24"
+              >
+                <ChevronLeft className="mr-1 h-4 w-4" />
+                Back
+              </Button>
+
+              <Button
+                onClick={handleMarkDone}
+                disabled={isCurrentStepCompleted}
+                className="max-w-xs flex-1"
+              >
+                <Check className="mr-1.5 h-4 w-4" />
+                Done
+              </Button>
+
+              <Button
+                variant="outline"
+                onClick={handleNext}
+                disabled={isLastStep}
+                className="w-24"
+              >
+                Next
+                <ChevronRight className="ml-1 h-4 w-4" />
+              </Button>
+            </div>
+          </footer>
+        </main>
+      </div>
+    </div>
   );
 }
-

--- a/src/app/recipe/[slug]/_components/CookingTips.tsx
+++ b/src/app/recipe/[slug]/_components/CookingTips.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { ArrowRightLeft, Lightbulb, Wrench } from "lucide-react";
+import type { IngredientSwap } from "./AdaptThisRecipe";
+
+interface CookingTipsProps {
+  swaps?: IngredientSwap[];
+}
+
+/**
+ * Formats a swap quantity for display.
+ * @param quantity - Numeric quantity
+ * @param unit - Unit string
+ * @returns Formatted quantity string
+ */
+function formatSwapQuantity(quantity: number, unit: string): string {
+  const formatted =
+    quantity % 1 === 0
+      ? quantity.toString()
+      : quantity.toFixed(2).replace(/\.?0+$/, "");
+  return unit ? `${formatted} ${unit}` : formatted;
+}
+
+/**
+ * Cooking support card: key cues, common fixes, and ingredient swaps stacked
+ * for quick scanning while cooking.
+ * @param swaps - Ingredient substitution suggestions from the adapted view
+ */
+export function CookingTips({ swaps = [] }: CookingTipsProps): JSX.Element {
+  return (
+    <section className="mt-8" aria-label="Cooking tips">
+      <div className="overflow-hidden rounded-2xl border border-border/70 bg-card shadow-soft">
+        <div className="border-b border-border/60 px-5 py-4">
+          <h3 className="font-display text-lg font-semibold tracking-tight">
+            While you cook
+          </h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Cues, fixes, and swaps
+          </p>
+        </div>
+
+        <div className="divide-y divide-border/60">
+          <div className="px-5 py-4">
+            <div className="mb-2.5 flex items-center gap-2 text-sm font-medium">
+              <span className="flex h-6 w-6 items-center justify-center rounded-md bg-herb-muted text-herb">
+                <Lightbulb className="h-3.5 w-3.5" aria-hidden />
+              </span>
+              Key cues
+            </div>
+            <ul className="space-y-1.5 text-sm leading-relaxed text-muted-foreground">
+              <li>Look for glossy sauce.</li>
+              <li>Aromatics should be fragrant, not browned.</li>
+              <li>Taste and adjust before serving.</li>
+            </ul>
+          </div>
+
+          <div className="px-5 py-4">
+            <div className="mb-2.5 flex items-center gap-2 text-sm font-medium">
+              <span className="flex h-6 w-6 items-center justify-center rounded-md bg-herb-muted text-herb">
+                <Wrench className="h-3.5 w-3.5" aria-hidden />
+              </span>
+              Common fixes
+            </div>
+            <ul className="space-y-1.5 text-sm leading-relaxed text-muted-foreground">
+              <li>Too thick? Add a splash of water.</li>
+              <li>Too thin? Simmer 2–3 minutes longer.</li>
+              <li>Too salty? Add acid or unsalted starch.</li>
+            </ul>
+          </div>
+
+          <div className="px-5 py-4">
+            <div className="mb-2.5 flex items-center gap-2 text-sm font-medium">
+              <span className="flex h-6 w-6 items-center justify-center rounded-md bg-herb-muted text-herb">
+                <ArrowRightLeft className="h-3.5 w-3.5" aria-hidden />
+              </span>
+              Swaps
+              {swaps.length > 0 ? (
+                <span className="text-xs font-normal text-muted-foreground">
+                  ({swaps.length})
+                </span>
+              ) : null}
+            </div>
+            {swaps.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No swap suggestions for this recipe yet.
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {swaps.map((swap) => (
+                  <div key={swap.originalIngredientId}>
+                    <p className="text-sm font-medium text-foreground">
+                      {swap.originalName}
+                    </p>
+                    <ul className="mt-1 space-y-1">
+                      {swap.substitutes.map((sub) => (
+                        <li
+                          key={sub.ingredientId}
+                          className="text-sm text-muted-foreground"
+                        >
+                          <span className="text-foreground">
+                            {sub.ingredientName}
+                          </span>
+                          {" — "}
+                          {formatSwapQuantity(sub.quantity, sub.unit)}
+                          {sub.notes ? ` (${sub.notes})` : ""}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/recipe/[slug]/_components/FavoriteButton.tsx
+++ b/src/app/recipe/[slug]/_components/FavoriteButton.tsx
@@ -5,6 +5,7 @@ import { Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useUser } from "@clerk/nextjs";
 import { checkIfFavorite, toggleFavorite } from "~/app/_actions/favorites";
+import { cn } from "~/lib/utils";
 
 interface FavoriteButtonProps {
   recipeId: number;
@@ -14,7 +15,9 @@ interface FavoriteButtonProps {
  * Client-side favorite button that handles its own data fetching.
  * This prevents auth checks from blocking the main recipe content render.
  */
-export function FavoriteButton({ recipeId }: FavoriteButtonProps): JSX.Element | null {
+export function FavoriteButton({
+  recipeId,
+}: FavoriteButtonProps): JSX.Element | null {
   const { isSignedIn, isLoaded } = useUser();
   const [isFavorite, setIsFavorite] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -56,17 +59,21 @@ export function FavoriteButton({ recipeId }: FavoriteButtonProps): JSX.Element |
   return (
     <Button
       type="button"
-      variant="ghost"
-      size="sm"
       onClick={handleToggle}
       disabled={isPending || isLoading}
+      className={cn(
+        "shadow-soft",
+        isFavorite && "bg-accent text-accent-foreground hover:bg-accent/90",
+      )}
     >
       <Star
-        className={`h-5 w-5 transition-all active:-translate-y-1 ${
-          isFavorite ? "fill-accent" : ""
-        } ${isLoading ? "opacity-50" : ""}`}
+        className={cn(
+          "mr-1.5 h-4 w-4 transition-transform",
+          isFavorite && "fill-current",
+          isLoading && "opacity-50",
+        )}
       />
+      {isFavorite ? "Saved" : "Save"}
     </Button>
   );
 }
-

--- a/src/app/recipe/[slug]/_components/FullRecipePage.tsx
+++ b/src/app/recipe/[slug]/_components/FullRecipePage.tsx
@@ -12,13 +12,6 @@ import { AlertTriangle, Loader2, Check } from "lucide-react";
 import { type JSONContent } from "novel";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
 import { SignedIn, SignedOut } from "@clerk/nextjs";
 import { RecipeHeader } from "./RecipeHeader";
 import {
@@ -33,10 +26,7 @@ import { MoreLikeThis } from "./MoreLikeThis";
 import { AdminWrapper } from "./AdminWrapper";
 import { checkIfFavorite, toggleFavorite } from "~/app/_actions/favorites";
 import { saveGeneralNote } from "~/app/_actions/userNotes";
-import {
-  fetchRecipeView,
-  onPublishRecipe,
-} from "./actions";
+import { fetchRecipeView, onPublishRecipe } from "./actions";
 import type {
   RecipeViewDTO,
   RecipeViewIngredient,
@@ -140,7 +130,7 @@ function mapViewIngredients(
 /**
  * Builds swap suggestions from computed ingredients that have substitutions.
  * @param ingredients - Computed recipe view ingredients
- * @returns Ingredient swap groups for the adapt drawer
+ * @returns Ingredient swap groups for cooking tips
  */
 function buildSwaps(ingredients: RecipeViewIngredient[]): IngredientSwap[] {
   return ingredients
@@ -159,10 +149,7 @@ function buildSwaps(ingredients: RecipeViewIngredient[]): IngredientSwap[] {
 }
 
 /**
- * Redesigned recipe page that feels like a cooking tool.
- * Features "Adapt this recipe" controls, scannable steps, and Cook Mode.
- * Desktop: Steps on left, Adapt + Ingredients on sticky right sidebar.
- * Mobile: Single column with sticky bottom action bar.
+ * Recipe detail page with hero photo, sticky ingredients, and tucked adapt controls.
  * @param recipe - The full recipe data
  * @param relatedRecipes - Related recipes for "More like this" section
  * @param adminEditSheet - Server component for admin edit functionality
@@ -299,139 +286,141 @@ export function FullRecipePageClient({
   return (
     <>
       {!recipe.published && (
-        <div className="mb-8 flex items-center justify-between rounded-md border border-accent/40 bg-accent/10 p-4 font-semibold text-accent">
-          <div>
-            <AlertTriangle
-              size={16}
-              className="mr-2 inline-block -translate-y-[2px]"
-            />
-            This recipe is not yet published. It will not be visible to others.
+        <div className="container pt-6">
+          <div className="flex items-center justify-between rounded-xl border border-accent/40 bg-accent/10 p-4 font-semibold text-accent">
+            <div>
+              <AlertTriangle
+                size={16}
+                className="mr-2 inline-block -translate-y-[2px]"
+              />
+              This recipe is not yet published. It will not be visible to others.
+            </div>
+            <form action={() => onPublishRecipe(recipe.id, true)}>
+              <Button type="submit">Publish</Button>
+            </form>
           </div>
-          <form action={() => onPublishRecipe(recipe.id, true)}>
-            <Button type="submit">Publish</Button>
-          </form>
         </div>
       )}
 
-      <RecipeHeader recipe={recipe} tags={tags} servings={servings} />
+      <RecipeHeader
+        recipe={recipe}
+        tags={tags}
+        servings={servings}
+        onStartCookMode={handleStartCookMode}
+      />
 
-      <div className="mb-4 lg:hidden">
-        <AdaptThisRecipe
-          servings={servings}
-          onServingsChange={setServings}
-          difficulty={difficulty}
-          onDifficultyChange={setDifficulty}
-          hasV2Data={hasV2Data}
-          swaps={swaps}
-        />
-      </div>
+      <div className="container py-8 lg:py-10">
+        <div className="flex flex-col gap-8 lg:flex-row lg:gap-12">
+          <aside className="w-full shrink-0 lg:sticky lg:top-24 lg:w-80 lg:self-start">
+            <div className="space-y-4">
+              {adminEditSheet && (
+                <AdminWrapper>{adminEditSheet}</AdminWrapper>
+              )}
 
-      <div className="mb-6 lg:hidden">
-        <IngredientsPanel
-          ingredients={displayIngredients}
-          servingsMultiplier={servingsMultiplier}
-          isLoading={isViewLoading}
-          collapsible
-          defaultOpen={false}
-        />
-      </div>
+              <div className="lg:hidden">
+                <IngredientsPanel
+                  ingredients={displayIngredients}
+                  servingsMultiplier={servingsMultiplier}
+                  isLoading={isViewLoading}
+                  collapsible
+                  defaultOpen
+                />
+              </div>
 
-      <div className="flex gap-8">
-        <main className="min-w-0 flex-1">
-          <StepsList
-            steps={useV2View ? null : recipe.steps}
-            stepInstructions={stepInstructions}
-            onStartCookMode={handleStartCookMode}
-            recipeId={recipe.id}
-            isSignedIn={!!isSignedIn}
-            stepNotes={userNotes?.stepNotes}
-            isLoading={isViewLoading}
-          />
+              <div className="hidden lg:block">
+                <IngredientsPanel
+                  ingredients={displayIngredients}
+                  servingsMultiplier={servingsMultiplier}
+                  isLoading={isViewLoading}
+                />
+              </div>
 
-          <Card className="mt-8">
-            <CardHeader>
-              <CardTitle>Make it yours</CardTitle>
-              <CardDescription>
-                Save swaps, timing tweaks, and reminders for next time.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <SignedIn>
-                <div className="space-y-3">
-                  <Textarea
-                    value={generalNote}
-                    onChange={(e) => setGeneralNote(e.target.value)}
-                    placeholder="Your notes for this recipe..."
-                    className="min-h-[100px]"
-                    maxLength={2000}
-                  />
-                  <div className="flex items-center gap-2">
-                    <Button
-                      onClick={handleSaveGeneralNote}
-                      disabled={
-                        generalNoteSaveState === "saving" ||
-                        generalNote === savedGeneralNote
-                      }
-                    >
-                      {generalNoteSaveState === "saving" ? (
-                        <>
-                          <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-                          Saving...
-                        </>
-                      ) : generalNoteSaveState === "saved" ? (
-                        <>
-                          <Check className="mr-1.5 h-4 w-4" />
-                          Saved
-                        </>
-                      ) : (
-                        "Save notes"
-                      )}
-                    </Button>
-                  </div>
-                  {generalNoteSaveState === "error" && (
-                    <p className="text-sm text-destructive">
-                      {generalNoteError}
-                    </p>
-                  )}
-                </div>
-              </SignedIn>
-              <SignedOut>
-                <p className="text-sm text-muted-foreground">
-                  Log in to save personal notes.
-                </p>
-              </SignedOut>
-            </CardContent>
-          </Card>
+              <AdaptThisRecipe
+                servings={servings}
+                onServingsChange={setServings}
+                difficulty={difficulty}
+                onDifficultyChange={setDifficulty}
+                hasV2Data={hasV2Data}
+                defaultCollapsed
+              />
+            </div>
+          </aside>
 
-          {dangerZoneDialog && (
-            <AdminWrapper>
-              <div className="mt-8">{dangerZoneDialog}</div>
-            </AdminWrapper>
-          )}
-
-          <MoreLikeThis recipes={relatedRecipes} />
-        </main>
-
-        <aside className="hidden w-80 shrink-0 lg:block">
-          <div className="sticky top-24 space-y-4">
-            {adminEditSheet && <AdminWrapper>{adminEditSheet}</AdminWrapper>}
-
-            <AdaptThisRecipe
-              servings={servings}
-              onServingsChange={setServings}
-              difficulty={difficulty}
-              onDifficultyChange={setDifficulty}
-              hasV2Data={hasV2Data}
+          <main className="min-w-0 flex-1">
+            <StepsList
+              steps={useV2View ? null : recipe.steps}
+              stepInstructions={stepInstructions}
+              recipeId={recipe.id}
+              isSignedIn={!!isSignedIn}
+              stepNotes={userNotes?.stepNotes}
+              isLoading={isViewLoading}
               swaps={swaps}
             />
 
-            <IngredientsPanel
-              ingredients={displayIngredients}
-              servingsMultiplier={servingsMultiplier}
-              isLoading={isViewLoading}
-            />
-          </div>
-        </aside>
+            <section className="mt-10 rounded-2xl border border-border/70 bg-gradient-to-br from-card via-card to-herb-muted/40 p-5 sm:p-6">
+              <h2 className="font-display text-xl font-semibold tracking-tight">
+                Make it yours
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Save swaps, timing tweaks, and reminders for next time.
+              </p>
+              <div className="mt-4">
+                <SignedIn>
+                  <div className="space-y-3">
+                    <Textarea
+                      value={generalNote}
+                      onChange={(e) => setGeneralNote(e.target.value)}
+                      placeholder="Your notes for this recipe..."
+                      className="min-h-[100px] bg-background/70"
+                      maxLength={2000}
+                    />
+                    <div className="flex items-center gap-2">
+                      <Button
+                        onClick={handleSaveGeneralNote}
+                        disabled={
+                          generalNoteSaveState === "saving" ||
+                          generalNote === savedGeneralNote
+                        }
+                      >
+                        {generalNoteSaveState === "saving" ? (
+                          <>
+                            <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                            Saving...
+                          </>
+                        ) : generalNoteSaveState === "saved" ? (
+                          <>
+                            <Check className="mr-1.5 h-4 w-4" />
+                            Saved
+                          </>
+                        ) : (
+                          "Save notes"
+                        )}
+                      </Button>
+                    </div>
+                    {generalNoteSaveState === "error" && (
+                      <p className="text-sm text-destructive">
+                        {generalNoteError}
+                      </p>
+                    )}
+                  </div>
+                </SignedIn>
+                <SignedOut>
+                  <p className="text-sm text-muted-foreground">
+                    Log in to save personal notes.
+                  </p>
+                </SignedOut>
+              </div>
+            </section>
+
+            {dangerZoneDialog && (
+              <AdminWrapper>
+                <div className="mt-8">{dangerZoneDialog}</div>
+              </AdminWrapper>
+            )}
+
+            <MoreLikeThis recipes={relatedRecipes} />
+          </main>
+        </div>
       </div>
 
       <div className="h-20 lg:hidden" />
@@ -445,7 +434,6 @@ export function FullRecipePageClient({
         difficulty={difficulty}
         onDifficultyChange={setDifficulty}
         hasV2Data={hasV2Data}
-        swaps={swaps}
       />
 
       <CookModeOverlay

--- a/src/app/recipe/[slug]/_components/IngredientsPanel.tsx
+++ b/src/app/recipe/[slug]/_components/IngredientsPanel.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { ChevronDown } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   Collapsible,
@@ -35,7 +34,10 @@ interface IngredientsPanelProps {
  * @param quantity - Original quantity string
  * @returns Object with numeric value and unit
  */
-function parseQuantity(quantity: string): { value: number | null; unit: string } {
+function parseQuantity(quantity: string): {
+  value: number | null;
+  unit: string;
+} {
   const match = quantity.match(/^([\d./]+)\s*(.*)$/);
   if (!match) return { value: null, unit: quantity };
 
@@ -64,14 +66,15 @@ function formatScaledQuantity(quantity: string, multiplier: number): string {
 
   const scaled = value * multiplier;
   const formatted =
-    scaled % 1 === 0 ? scaled.toString() : scaled.toFixed(2).replace(/\.?0+$/, "");
+    scaled % 1 === 0
+      ? scaled.toString()
+      : scaled.toFixed(2).replace(/\.?0+$/, "");
 
   return unit ? `${formatted} ${unit}` : formatted;
 }
 
 /**
- * Ingredients panel with checkboxes and optional collapsible behavior.
- * Displays quantity bold with prep notes aligned.
+ * Ingredients checklist with optional collapsible behavior.
  * @param ingredients - Array of ingredient items
  * @param servingsMultiplier - Multiplier for scaling quantities
  * @param collapsible - Whether to render as collapsible (for mobile)
@@ -85,7 +88,9 @@ export function IngredientsPanel({
   defaultOpen = true,
   isLoading = false,
 }: IngredientsPanelProps): JSX.Element {
-  const [checkedItems, setCheckedItems] = useState<Record<number, boolean>>({});
+  const [checkedItems, setCheckedItems] = useState<Record<number, boolean>>(
+    {},
+  );
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   useEffect(() => {
@@ -111,7 +116,7 @@ export function IngredientsPanel({
     }));
   };
 
-  const content = (
+  const list = (
     <>
       {isLoading ? (
         <p className="text-sm text-muted-foreground">Updating ingredients...</p>
@@ -121,7 +126,10 @@ export function IngredientsPanel({
         <ul className="space-y-3">
           {ingredients.map(({ ingredient, quantity, ingredientId }) => {
             const isChecked = checkedItems[ingredientId] ?? false;
-            const scaledQuantity = formatScaledQuantity(quantity, servingsMultiplier);
+            const scaledQuantity = formatScaledQuantity(
+              quantity,
+              servingsMultiplier,
+            );
 
             return (
               <li key={ingredientId} className="flex items-start gap-3">
@@ -136,12 +144,14 @@ export function IngredientsPanel({
                 <label
                   htmlFor={`ingredient-${ingredientId}`}
                   className={cn(
-                    "flex-1 cursor-pointer text-sm leading-tight",
-                    isChecked && "text-muted-foreground line-through"
+                    "flex-1 cursor-pointer text-sm leading-snug",
+                    isChecked && "text-muted-foreground line-through",
                   )}
                 >
-                  <span className="font-semibold">{scaledQuantity}</span>{" "}
-                  {ingredient.name}
+                  <span className="font-semibold tabular-nums text-foreground">
+                    {scaledQuantity}
+                  </span>{" "}
+                  <span className="text-foreground/90">{ingredient.name}</span>
                 </label>
               </li>
             );
@@ -153,36 +163,43 @@ export function IngredientsPanel({
 
   if (collapsible) {
     return (
-      <Card>
-        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <div className="overflow-hidden rounded-2xl border border-border/70 bg-card shadow-soft">
           <CollapsibleTrigger asChild>
-            <CardHeader className="cursor-pointer pb-3">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-lg">Ingredients</CardTitle>
-                <ChevronDown
-                  className={cn(
-                    "h-5 w-5 text-muted-foreground transition-transform",
-                    isOpen && "rotate-180"
-                  )}
-                />
-              </div>
-            </CardHeader>
+            <button
+              type="button"
+              className="flex w-full items-center justify-between px-5 py-4 text-left"
+            >
+              <h2 className="font-display text-lg font-semibold tracking-tight">
+                Ingredients
+              </h2>
+              <ChevronDown
+                className={cn(
+                  "h-5 w-5 text-muted-foreground transition-transform",
+                  isOpen && "rotate-180",
+                )}
+              />
+            </button>
           </CollapsibleTrigger>
           <CollapsibleContent>
-            <CardContent className="pt-0">{content}</CardContent>
+            <div className="border-t border-border/60 px-5 py-4">{list}</div>
           </CollapsibleContent>
-        </Collapsible>
-      </Card>
+        </div>
+      </Collapsible>
     );
   }
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-lg">Ingredients</CardTitle>
-      </CardHeader>
-      <CardContent>{content}</CardContent>
-    </Card>
+    <div className="overflow-hidden rounded-2xl border border-border/70 bg-card shadow-soft">
+      <div className="border-b border-border/60 px-5 py-4">
+        <h2 className="font-display text-lg font-semibold tracking-tight">
+          Ingredients
+        </h2>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Check off as you go
+        </p>
+      </div>
+      <div className="px-5 py-4">{list}</div>
+    </div>
   );
 }
-

--- a/src/app/recipe/[slug]/_components/MobileStickyBar.tsx
+++ b/src/app/recipe/[slug]/_components/MobileStickyBar.tsx
@@ -10,10 +10,7 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@/components/ui/drawer";
-import {
-  AdaptThisRecipe,
-  type IngredientSwap,
-} from "./AdaptThisRecipe";
+import { AdaptThisRecipe } from "./AdaptThisRecipe";
 import { AuthGateModal } from "./AuthGateModal";
 
 type DifficultyLevel = "EASY" | "MEDIUM" | "HARD";
@@ -27,12 +24,10 @@ interface MobileStickyBarProps {
   difficulty?: DifficultyLevel;
   onDifficultyChange?: (difficulty: DifficultyLevel) => void;
   hasV2Data?: boolean;
-  swaps?: IngredientSwap[];
 }
 
 /**
- * Mobile sticky bottom bar with quick action buttons.
- * Contains Cook Mode, Adapt drawer trigger, and Save button.
+ * Mobile sticky bottom bar with save, tucked adapt drawer, and deemphasized cook mode.
  * @param isFavorite - Whether the recipe is favorited
  * @param onToggleFavorite - Callback to toggle favorite
  * @param onStartCookMode - Callback to start cook mode
@@ -41,7 +36,6 @@ interface MobileStickyBarProps {
  * @param difficulty - Current difficulty level (v2)
  * @param onDifficultyChange - Callback when difficulty changes (v2)
  * @param hasV2Data - Whether this recipe has v2 difficulty variations
- * @param swaps - Ingredient substitution suggestions
  */
 export function MobileStickyBar({
   isFavorite,
@@ -52,7 +46,6 @@ export function MobileStickyBar({
   difficulty,
   onDifficultyChange,
   hasV2Data = false,
-  swaps = [],
 }: MobileStickyBarProps): JSX.Element {
   const { isSignedIn, isLoaded } = useUser();
   const [showAdaptDrawer, setShowAdaptDrawer] = useState(false);
@@ -78,20 +71,35 @@ export function MobileStickyBar({
 
   return (
     <>
-      <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:hidden">
+      <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border/70 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:hidden">
         <div className="container flex items-center justify-between gap-2 px-4 py-3">
-          <Button onClick={onStartCookMode} className="flex-1">
-            Start Cook Mode
+          <Button
+            onClick={handleSaveClick}
+            className="flex-1 shadow-soft"
+            aria-label={isFavorite ? "Remove favorite" : "Save favorite"}
+          >
+            {isFavorite ? (
+              <BookmarkCheck className="mr-1.5 h-4 w-4 fill-current" />
+            ) : (
+              <Bookmark className="mr-1.5 h-4 w-4" />
+            )}
+            {isFavorite ? "Saved" : "Save"}
           </Button>
-          <Button variant="outline" size="icon" onClick={handleAdaptClick}>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={handleAdaptClick}
+            aria-label="Adapt recipe"
+          >
             <Sliders className="h-4 w-4" />
           </Button>
-          <Button variant="outline" size="icon" onClick={handleSaveClick}>
-            {isFavorite ? (
-              <BookmarkCheck className="h-4 w-4 fill-current" />
-            ) : (
-              <Bookmark className="h-4 w-4" />
-            )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onStartCookMode}
+            className="text-muted-foreground"
+          >
+            Cook Mode
           </Button>
         </div>
       </div>
@@ -108,7 +116,7 @@ export function MobileStickyBar({
               difficulty={difficulty}
               onDifficultyChange={onDifficultyChange}
               hasV2Data={hasV2Data}
-              swaps={swaps}
+              embedded
             />
           </div>
         </DrawerContent>

--- a/src/app/recipe/[slug]/_components/MoreLikeThis.tsx
+++ b/src/app/recipe/[slug]/_components/MoreLikeThis.tsx
@@ -57,7 +57,7 @@ function CompactRecipeCard({
   return (
     <Link
       href={`/recipe/${recipe.slug}`}
-      className="group block overflow-hidden rounded-lg border border-border bg-card transition-all hover:border-primary/30 hover:shadow-md"
+      className="group block overflow-hidden rounded-2xl border border-border/70 bg-card transition-all duration-200 hover:border-foreground/15 hover:shadow-lift"
     >
       <div className="relative aspect-[16/10] overflow-hidden bg-muted">
         {recipe.heroImage?.url ? (
@@ -130,8 +130,13 @@ export function MoreLikeThis({ recipes }: MoreLikeThisProps): JSX.Element | null
   if (recipes.length === 0) return null;
 
   return (
-    <section className="mt-12">
-      <h2 className="mb-4 text-xl font-semibold">More like this</h2>
+    <section className="mt-14 border-t border-border/70 pt-10">
+      <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-accent">
+        Keep exploring
+      </p>
+      <h2 className="mt-1 mb-5 font-display text-2xl font-semibold tracking-tight">
+        More like this
+      </h2>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {recipes.slice(0, 6).map((recipe) => (
           <CompactRecipeCard key={recipe.id} recipe={recipe} />

--- a/src/app/recipe/[slug]/_components/RecipeHeader.tsx
+++ b/src/app/recipe/[slug]/_components/RecipeHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Clock, ChefHat, Users, Share2, Printer } from "lucide-react";
+import Image from "next/image";
+import { Clock, ChefHat, Users, Share2, Printer, Soup } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,9 +22,11 @@ interface RecipeHeaderProps {
     cookTime: number | null;
     difficulty: string | null;
     slug: string;
+    heroImage: { url: string; name: string } | null;
   };
   tags: Array<{ id: number; name: string; tagType: string | null }>;
   servings: number;
+  onStartCookMode: () => void;
 }
 
 /**
@@ -34,7 +37,7 @@ interface RecipeHeaderProps {
  */
 function formatTotalTime(
   prepTime: number | null,
-  cookTime: number | null
+  cookTime: number | null,
 ): string | null {
   const total = (prepTime ?? 0) + (cookTime ?? 0);
   if (total === 0) return null;
@@ -59,16 +62,17 @@ function formatDifficulty(difficulty: string | null): string | null {
 }
 
 /**
- * Recipe header with title, meta row, tags, and action buttons.
- * Designed to be the first thing users see - shows key info immediately.
- * @param recipe - The recipe data
+ * Full-bleed hero header with photo, title, meta, and primary cook CTA.
+ * @param recipe - The recipe data including hero image
  * @param tags - Array of recipe tags
  * @param servings - Current servings count
+ * @param onStartCookMode - Opens cook mode overlay
  */
 export function RecipeHeader({
   recipe,
   tags,
   servings,
+  onStartCookMode,
 }: RecipeHeaderProps): JSX.Element {
   const totalTime = formatTotalTime(recipe.prepTime, recipe.cookTime);
   const difficultyLabel = formatDifficulty(recipe.difficulty);
@@ -89,79 +93,115 @@ export function RecipeHeader({
   };
 
   return (
-    <header className="mb-6 space-y-4">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="space-y-2">
-          <h1 className="font-display text-3xl font-semibold tracking-tight lg:text-4xl">
-            {recipe.name}
-          </h1>
-          {recipe.description && (
-            <p className="max-w-2xl text-base text-muted-foreground">
-              {recipe.description}
-            </p>
-          )}
-        </div>
-
-        <div className="flex items-center gap-2">
-          <FavoriteButton recipeId={recipe.id} />
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="outline" size="sm" onClick={handleShare}>
-                  <Share2 className="mr-1.5 h-4 w-4" />
-                  Share
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Copy link</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" onClick={handlePrint}>
-                  <Printer className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Print</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+    <header className="relative">
+      <div className="relative h-[42vh] min-h-[280px] w-full overflow-hidden bg-muted sm:h-[52vh] sm:min-h-[360px]">
+        {recipe.heroImage?.url ? (
+          <Image
+            src={recipe.heroImage.url}
+            alt={recipe.heroImage.name || recipe.name}
+            fill
+            priority
+            sizes="100vw"
+            className="object-cover animate-fade-in"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center bg-gradient-to-br from-herb-muted via-muted to-secondary">
+            <Soup className="h-20 w-20 text-herb/40" aria-hidden />
+          </div>
+        )}
+        <div
+          className="absolute inset-0 bg-gradient-to-t from-foreground/75 via-foreground/25 to-transparent"
+          aria-hidden
+        />
+        <div className="absolute inset-x-0 bottom-0">
+          <div className="container pb-8 pt-16 sm:pb-10">
+            <div className="max-w-3xl animate-rise space-y-3">
+              {displayTags.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {displayTags.map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="text-[11px] font-medium uppercase tracking-[0.14em] text-primary-foreground/80"
+                    >
+                      {tag.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <h1 className="font-display text-4xl font-semibold leading-[1.1] tracking-tight text-primary-foreground sm:text-5xl lg:text-6xl">
+                {recipe.name}
+              </h1>
+              {recipe.description && (
+                <p className="max-w-2xl text-base leading-relaxed text-primary-foreground/85 sm:text-lg">
+                  {recipe.description}
+                </p>
+              )}
+            </div>
+          </div>
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-        {totalTime && (
-          <span className="flex items-center gap-1.5">
-            <Clock className="h-4 w-4" />
-            {totalTime}
-          </span>
-        )}
-        {recipe.prepTime && recipe.cookTime && (
-          <span className="text-xs">
-            (Prep: {recipe.prepTime}m, Cook: {recipe.cookTime}m)
-          </span>
-        )}
-        {difficultyLabel && (
-          <Badge variant="secondary" className="font-normal">
-            <ChefHat className="mr-1 h-3 w-3" />
-            {difficultyLabel}
-          </Badge>
-        )}
-        <span className="flex items-center gap-1.5">
-          <Users className="h-4 w-4" />
-          {servings} servings
-        </span>
-      </div>
+      <div className="border-b border-border/80 bg-card/80 backdrop-blur-sm">
+        <div className="container flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-muted-foreground">
+            {totalTime && (
+              <span className="flex items-center gap-1.5">
+                <Clock className="h-4 w-4 text-accent" aria-hidden />
+                <span className="font-medium text-foreground">{totalTime}</span>
+                {recipe.prepTime != null && recipe.cookTime != null && (
+                  <span className="text-xs">
+                    · prep {recipe.prepTime}m · cook {recipe.cookTime}m
+                  </span>
+                )}
+              </span>
+            )}
+            {difficultyLabel && (
+              <Badge variant="secondary" className="font-normal">
+                <ChefHat className="mr-1 h-3 w-3" aria-hidden />
+                {difficultyLabel}
+              </Badge>
+            )}
+            <span className="flex items-center gap-1.5">
+              <Users className="h-4 w-4" aria-hidden />
+              {servings} servings
+            </span>
+          </div>
 
-      {displayTags.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {displayTags.map((tag) => (
-            <Badge key={tag.id} variant="outline" className="font-normal">
-              {tag.name}
-            </Badge>
-          ))}
+          <div className="flex items-center gap-2">
+            <FavoriteButton recipeId={recipe.id} />
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={handleShare}>
+                    <Share2 className="h-4 w-4" />
+                    <span className="sr-only">Share</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Copy link</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="icon" onClick={handlePrint}>
+                    <Printer className="h-4 w-4" />
+                    <span className="sr-only">Print</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Print</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onStartCookMode}
+              className="text-muted-foreground"
+            >
+              Cook Mode
+            </Button>
+          </div>
         </div>
-      )}
+      </div>
     </header>
   );
 }
-

--- a/src/app/recipe/[slug]/_components/StepCard.tsx
+++ b/src/app/recipe/[slug]/_components/StepCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, type MouseEvent } from "react";
 import { MessageSquare, Check, Loader2, X } from "lucide-react";
 import { cn } from "~/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -18,9 +18,7 @@ interface StepCardProps {
 }
 
 /**
- * Individual step card with step number and content.
- * Designed for scannability with clear visual hierarchy.
- * Supports per-step notes for logged-in users.
+ * Individual step with editorial numbering and optional notes.
  * @param stepNumber - The step number (1-indexed)
  * @param content - The step text content
  * @param isActive - Whether this step is currently active
@@ -43,7 +41,9 @@ export function StepCard({
   const [isEditing, setIsEditing] = useState(false);
   const [noteValue, setNoteValue] = useState(note);
   const [savedNote, setSavedNote] = useState(note);
-  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [saveState, setSaveState] = useState<
+    "idle" | "saving" | "saved" | "error"
+  >("idle");
   const [errorMessage, setErrorMessage] = useState("");
 
   const hasNote = savedNote.trim().length > 0;
@@ -74,7 +74,7 @@ export function StepCard({
     setErrorMessage("");
   }, [savedNote]);
 
-  const handleStartEdit = useCallback((e: React.MouseEvent) => {
+  const handleStartEdit = useCallback((e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     setIsEditing(true);
   }, []);
@@ -82,37 +82,41 @@ export function StepCard({
   return (
     <div
       className={cn(
-        "group relative rounded-lg border p-4 transition-all",
-        isActive && "border-accent bg-accent/5 ring-1 ring-accent/40",
-        isCompleted && "border-herb/30 bg-herb-muted/50",
-        !isActive && !isCompleted && "border-border hover:border-accent/40",
-        onClick && "cursor-pointer"
+        "group relative rounded-2xl px-4 py-4 transition-all duration-200 sm:px-5",
+        isActive && "bg-accent/5 ring-1 ring-accent/30",
+        isCompleted && "bg-herb-muted/60",
+        !isActive &&
+          !isCompleted &&
+          "bg-card/40 hover:bg-card hover:shadow-soft",
+        onClick && "cursor-pointer",
       )}
       onClick={onClick}
     >
       <div className="flex gap-4">
         <div
           className={cn(
-            "flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-sm font-semibold",
+            "flex h-9 w-9 shrink-0 items-center justify-center rounded-full font-display text-sm font-semibold tabular-nums transition-colors",
             isActive && "bg-accent text-accent-foreground",
             isCompleted && "bg-herb text-herb-foreground",
-            !isActive && !isCompleted && "bg-muted text-muted-foreground"
+            !isActive &&
+              !isCompleted &&
+              "bg-secondary text-muted-foreground group-hover:text-foreground",
           )}
         >
-          {isCompleted ? "✓" : stepNumber}
+          {isCompleted ? <Check className="h-4 w-4" /> : stepNumber}
         </div>
-        <div className="flex-1 pt-1">
+        <div className="min-w-0 flex-1 pt-1">
           <p
             className={cn(
-              "text-[15px] leading-relaxed",
-              isCompleted && "text-muted-foreground line-through"
+              "text-[15px] leading-relaxed text-foreground/90",
+              isCompleted && "text-muted-foreground line-through",
             )}
           >
             {content}
           </p>
 
           {hasNote && !isEditing && (
-            <div className="mt-2 rounded bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+            <div className="mt-3 rounded-lg bg-muted/60 px-3 py-2 text-sm text-muted-foreground">
               <MessageSquare className="mr-1.5 inline-block h-3.5 w-3.5" />
               {savedNote}
             </div>
@@ -122,7 +126,7 @@ export function StepCard({
             <button
               type="button"
               onClick={handleStartEdit}
-              className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
             >
               <MessageSquare className="h-3.5 w-3.5" />
               {hasNote ? "Edit note" : "Add note"}
@@ -130,7 +134,10 @@ export function StepCard({
           )}
 
           {isSignedIn && isEditing && (
-            <div className="mt-3 space-y-2" onClick={(e) => e.stopPropagation()}>
+            <div
+              className="mt-3 space-y-2"
+              onClick={(e) => e.stopPropagation()}
+            >
               <Textarea
                 value={noteValue}
                 onChange={(e) => setNoteValue(e.target.value)}
@@ -179,4 +186,3 @@ export function StepCard({
     </div>
   );
 }
-

--- a/src/app/recipe/[slug]/_components/StepsList.tsx
+++ b/src/app/recipe/[slug]/_components/StepsList.tsx
@@ -2,25 +2,19 @@
 
 import { useState, useCallback } from "react";
 import { type JSONContent } from "novel";
-import { ChevronDown, Lightbulb, Wrench } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import { StepCard } from "./StepCard";
-import { cn } from "~/lib/utils";
+import { CookingTips } from "./CookingTips";
 import { saveStepNote } from "~/app/_actions/userNotes";
+import type { IngredientSwap } from "./AdaptThisRecipe";
 
 interface StepsListProps {
   steps?: JSONContent | null;
   stepInstructions?: string[];
-  onStartCookMode: () => void;
   recipeId: number;
   isSignedIn: boolean;
   stepNotes?: Record<number, string>;
   isLoading?: boolean;
+  swaps?: IngredientSwap[];
 }
 
 /**
@@ -63,32 +57,27 @@ function extractStepsFromContent(content: JSONContent | null): string[] {
 }
 
 /**
- * Steps list with decision support callouts.
- * Accepts Novel editor JSON or precomputed instruction strings (v2 adapt view).
- * Supports per-step notes for logged-in users.
+ * Steps list with cooking tips (cues, fixes, swaps).
  * @param steps - Novel editor JSON content (v1)
  * @param stepInstructions - Precomputed step strings (v2)
- * @param onStartCookMode - Callback to enter cook mode
  * @param recipeId - The recipe ID for saving notes
  * @param isSignedIn - Whether the user is signed in
  * @param stepNotes - Existing notes for each step
  * @param isLoading - Whether adapted steps are loading
+ * @param swaps - Ingredient substitution suggestions
  */
 export function StepsList({
   steps = null,
   stepInstructions,
-  onStartCookMode,
   recipeId,
   isSignedIn,
   stepNotes = {},
   isLoading = false,
+  swaps = [],
 }: StepsListProps): JSX.Element {
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
-  const [showCommonFixes, setShowCommonFixes] = useState(false);
-  const [showKeyCues, setShowKeyCues] = useState(false);
 
-  const stepStrings =
-    stepInstructions ?? extractStepsFromContent(steps);
+  const stepStrings = stepInstructions ?? extractStepsFromContent(steps);
 
   const toggleStepCompletion = (index: number): void => {
     setCompletedSteps((prev) => {
@@ -106,101 +95,51 @@ export function StepsList({
     async (stepIndex: number, note: string) => {
       return await saveStepNote(recipeId, stepIndex, note);
     },
-    [recipeId]
+    [recipeId],
   );
 
   return (
-    <section className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">Steps</h2>
-        <Button onClick={onStartCookMode}>Start Cook Mode</Button>
+    <section className="space-y-5">
+      <div>
+        <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-accent">
+          Method
+        </p>
+        <h2 className="mt-1 font-display text-2xl font-semibold tracking-tight">
+          Steps
+        </h2>
       </div>
 
       {isLoading ? (
-        <div className="rounded-lg border border-dashed p-8 text-center">
+        <div className="rounded-2xl border border-dashed border-border p-8 text-center">
           <p className="text-muted-foreground">Updating steps...</p>
         </div>
       ) : stepStrings.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-8 text-center">
+        <div className="rounded-2xl border border-dashed border-border p-8 text-center">
           <p className="text-muted-foreground">
             No steps available for this recipe.
           </p>
         </div>
       ) : (
-        <div className="space-y-3">
+        <ol className="space-y-3">
           {stepStrings.map((step, index) => (
-            <StepCard
-              key={index}
-              stepNumber={index + 1}
-              content={step}
-              isCompleted={completedSteps.has(index)}
-              onClick={() => toggleStepCompletion(index)}
-              isSignedIn={isSignedIn}
-              note={stepNotes[index] ?? ""}
-              onSaveNote={(note) => handleSaveStepNote(index, note)}
-            />
+            <li key={index}>
+              <StepCard
+                stepNumber={index + 1}
+                content={step}
+                isCompleted={completedSteps.has(index)}
+                onClick={() => toggleStepCompletion(index)}
+                isSignedIn={isSignedIn}
+                note={stepNotes[index] ?? ""}
+                onSaveNote={(note) => handleSaveStepNote(index, note)}
+              />
+            </li>
           ))}
-        </div>
+        </ol>
       )}
 
-      <div className="mt-6 space-y-2">
-        <Collapsible open={showCommonFixes} onOpenChange={setShowCommonFixes}>
-          <CollapsibleTrigger asChild>
-            <Button
-              variant="ghost"
-              className="w-full justify-between font-normal"
-            >
-              <span className="flex items-center gap-2">
-                <Wrench className="h-4 w-4" />
-                Common fixes
-              </span>
-              <ChevronDown
-                className={cn(
-                  "h-4 w-4 transition-transform",
-                  showCommonFixes && "rotate-180"
-                )}
-              />
-            </Button>
-          </CollapsibleTrigger>
-          <CollapsibleContent className="px-4 pt-2">
-            <ul className="space-y-2 text-sm text-muted-foreground">
-              <li>Too thick? Add a splash of water.</li>
-              <li>Too thin? Simmer 2-3 minutes longer.</li>
-              <li>Too salty? Add acid or unsalted starch.</li>
-            </ul>
-          </CollapsibleContent>
-        </Collapsible>
-
-        <Collapsible open={showKeyCues} onOpenChange={setShowKeyCues}>
-          <CollapsibleTrigger asChild>
-            <Button
-              variant="ghost"
-              className="w-full justify-between font-normal"
-            >
-              <span className="flex items-center gap-2">
-                <Lightbulb className="h-4 w-4" />
-                Key cues
-              </span>
-              <ChevronDown
-                className={cn(
-                  "h-4 w-4 transition-transform",
-                  showKeyCues && "rotate-180"
-                )}
-              />
-            </Button>
-          </CollapsibleTrigger>
-          <CollapsibleContent className="px-4 pt-2">
-            <ul className="space-y-2 text-sm text-muted-foreground">
-              <li>Look for glossy sauce.</li>
-              <li>Aromatics should be fragrant, not browned.</li>
-              <li>Taste and adjust before serving.</li>
-            </ul>
-          </CollapsibleContent>
-        </Collapsible>
-      </div>
+      <CookingTips swaps={swaps} />
     </section>
   );
 }
 
 export { extractStepsFromContent };
-

--- a/src/app/recipe/[slug]/loading.tsx
+++ b/src/app/recipe/[slug]/loading.tsx
@@ -1,103 +1,66 @@
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
 
-export default function RecipeLoading() {
+/**
+ * Loading skeleton matching the redesigned recipe page layout.
+ */
+export default function RecipeLoading(): JSX.Element {
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex flex-wrap gap-8">
-        {/* Left Column */}
-        <div className="flex-grow-[1] basis-64">
-          {/* Navigation */}
-          <div className="mb-8 flex justify-between align-middle">
-            <Button variant="default" size="sm" disabled>
-              <ArrowLeft size={16} /> Back
-            </Button>
-            <Skeleton className="h-9 w-24" />
-          </div>
+    <div>
+      <div className="relative h-[42vh] min-h-[280px] w-full bg-muted sm:h-[52vh] sm:min-h-[360px]">
+        <Skeleton className="h-full w-full rounded-none" />
+        <div className="absolute inset-x-0 bottom-0 container pb-8">
+          <Skeleton className="mb-3 h-3 w-40 bg-background/30" />
+          <Skeleton className="mb-3 h-12 w-2/3 max-w-xl bg-background/40" />
+          <Skeleton className="h-4 w-1/2 max-w-md bg-background/30" />
+        </div>
+      </div>
 
-          {/* Ingredients Card */}
-          <div className="sticky top-8">
-            <Card>
-              <CardHeader>
-                <Skeleton className="h-6 w-32" />
-              </CardHeader>
-              <CardContent className="space-y-4">
+      <div className="border-b border-border/80">
+        <div className="container flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex gap-4">
+            <Skeleton className="h-5 w-24" />
+            <Skeleton className="h-5 w-28" />
+            <Skeleton className="h-5 w-20" />
+          </div>
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-36" />
+            <Skeleton className="h-9 w-9" />
+            <Skeleton className="h-9 w-9" />
+          </div>
+        </div>
+      </div>
+
+      <div className="container py-8 lg:py-10">
+        <div className="flex flex-col gap-8 lg:flex-row lg:gap-12">
+          <aside className="w-full shrink-0 space-y-4 lg:w-80">
+            <div className="rounded-2xl border border-border/70 p-5">
+              <Skeleton className="mb-4 h-6 w-28" />
+              <div className="space-y-3">
                 {Array.from({ length: 6 }, (_, i) => (
-                  <div key={i} className="flex items-center gap-2">
+                  <div key={i} className="flex items-center gap-3">
                     <Skeleton className="h-4 w-4" />
                     <Skeleton className="h-4 w-full" />
                   </div>
                 ))}
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-
-        {/* Right Column */}
-        <div className="flex grow-[999] basis-0 flex-col gap-8">
-          {/* Recipe Card */}
-          <Card>
-            <CardHeader>
-              {/* Hero Image */}
-              <div className="relative mb-8 h-96">
-                <Skeleton className="h-full w-full rounded-lg" />
               </div>
+            </div>
+            <Skeleton className="h-12 w-full rounded-xl" />
+          </aside>
 
-              {/* Title and Description */}
-              <div className="flex items-end gap-2">
-                <Skeleton className="h-8 w-2/3" />
-                <Skeleton className="h-8 w-8" /> {/* Favorite button */}
-              </div>
-              <Skeleton className="h-4 w-full" />
-
-              {/* Tags */}
-              <div className="flex flex-row gap-2">
-                {Array.from({ length: 3 }, (_, i) => (
-                  <Skeleton key={i} className="h-6 w-20" />
-                ))}
-              </div>
-            </CardHeader>
-          </Card>
-
-          {/* Steps Card */}
-          <Card>
-            <CardHeader className="mb-4 border-b border-border">
-              <CardTitle as="h2" className="text-3xl">
-                Steps
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {Array.from({ length: 4 }, (_, i) => (
-                <div key={i} className="space-y-2">
-                  <Skeleton className="h-4 w-full" />
-                  <Skeleton className="h-4 w-5/6" />
+          <main className="min-w-0 flex-1 space-y-4">
+            <Skeleton className="h-8 w-32" />
+            {Array.from({ length: 4 }, (_, i) => (
+              <div key={i} className="rounded-2xl bg-card/40 p-5">
+                <div className="flex gap-4">
+                  <Skeleton className="h-9 w-9 rounded-full" />
+                  <div className="flex-1 space-y-2 pt-1">
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-5/6" />
+                  </div>
                 </div>
-              ))}
-            </CardContent>
-          </Card>
-
-          {/* Notes Card */}
-          <Card>
-            <CardHeader>
-              <CardTitle>
-                <Skeleton className="h-6 w-32" />
-              </CardTitle>
-              <CardDescription>
-                <Skeleton className="h-4 w-64" />
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-4 w-full" />
-            </CardContent>
-          </Card>
+              </div>
+            ))}
+          </main>
         </div>
       </div>
     </div>

--- a/src/app/recipe/[slug]/page.tsx
+++ b/src/app/recipe/[slug]/page.tsx
@@ -97,7 +97,7 @@ export default async function RecipePage({ params: { slug } }: Props) {
   const id = await getCachedRecipeIdFromSlug(slug);
 
   return (
-    <div className="container py-8">
+    <div>
       <RecipeViewTracker recipeId={id} />
       <Suspense fallback={<RecipeLoading />}>
         <FullRecipePageServer id={id} />


### PR DESCRIPTION
## Summary
- Redesign the recipe detail page with a full-bleed hero photo, editorial layout, and sticky ingredients
- Collapse Adapt controls and move swaps into a scannable “While you cook” card with cues and fixes
- Keep ingredients always visible in cook mode; deemphasize Cook Mode and promote Save/Favorite

## Test plan
- [ ] Open a recipe with a hero image and confirm the full-bleed hero, title overlay, and meta bar
- [ ] Confirm ingredients are sticky on desktop and open by default on mobile
- [ ] Confirm Adapt this recipe starts collapsed and expands correctly
- [ ] Confirm Key cues, Common fixes, and Swaps appear stacked in one always-open card
- [ ] Enter Cook Mode and confirm ingredients stay visible (sidebar desktop / strip mobile)
- [ ] Confirm only one quiet Cook Mode entry point in the header; Save is the primary action
- [ ] On mobile, confirm sticky bar prioritizes Save over Cook Mode


Made with [Cursor](https://cursor.com)