### PR TITLE
feat: restore cook check-ins, community reviews, and badges

### DIFF
--- a/drizzle/0006_true_kid_colt.sql
+++ b/drizzle/0006_true_kid_colt.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "hyper-recipes_cooking_sessions" ADD COLUMN "is_public" boolean DEFAULT true NOT NULL;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1596 @@
+{
+  "id": "6e1e3729-77c1-4a82-9a93-8f839dbc1383",
+  "prevId": "9aca06f5-063b-4f05-aa53-72111e0138a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.hyper-recipes_tag": {
+      "name": "hyper-recipes_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tag_types": {
+          "name": "tag_types",
+          "type": "tag_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_favorite_recipes": {
+      "name": "hyper-recipes_favorite_recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "favorites_user_recipe_idx": {
+          "name": "favorites_user_recipe_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hyper-recipes_favorite_recipes_recipe_id_hyper-recipes_recipes_id_fk": {
+          "name": "hyper-recipes_favorite_recipes_recipe_id_hyper-recipes_recipes_id_fk",
+          "tableFrom": "hyper-recipes_favorite_recipes",
+          "tableTo": "hyper-recipes_recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_recipes": {
+      "name": "hyper-recipes_recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hero_image_id": {
+          "name": "hero_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prep_time": {
+          "name": "prep_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cook_time": {
+          "name": "cook_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "name_index": {
+          "name": "name_index",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slug_index": {
+          "name": "slug_index",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hyper-recipes_recipes_hero_image_id_hyper-recipes_images_id_fk": {
+          "name": "hyper-recipes_recipes_hero_image_id_hyper-recipes_images_id_fk",
+          "tableFrom": "hyper-recipes_recipes",
+          "tableTo": "hyper-recipes_images",
+          "columnsFrom": [
+            "hero_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_images": {
+      "name": "hyper-recipes_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_ingredients": {
+      "name": "hyper-recipes_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_recipes_to_tags": {
+      "name": "hyper-recipes_recipes_to_tags",
+      "schema": "",
+      "columns": {
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "recipes_to_tags_tag_idx": {
+          "name": "recipes_to_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hyper-recipes_recipes_to_tags_recipe_id_hyper-recipes_recipes_id_fk": {
+          "name": "hyper-recipes_recipes_to_tags_recipe_id_hyper-recipes_recipes_id_fk",
+          "tableFrom": "hyper-recipes_recipes_to_tags",
+          "tableTo": "hyper-recipes_recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hyper-recipes_recipes_to_tags_tag_id_hyper-recipes_tag_id_fk": {
+          "name": "hyper-recipes_recipes_to_tags_tag_id_hyper-recipes_tag_id_fk",
+          "tableFrom": "hyper-recipes_recipes_to_tags",
+          "tableTo": "hyper-recipes_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hyper-recipes_recipes_to_tags_recipe_id_tag_id_pk": {
+          "name": "hyper-recipes_recipes_to_tags_recipe_id_tag_id_pk",
+          "columns": [
+            "recipe_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_recipe_ingredients": {
+      "name": "hyper-recipes_recipe_ingredients",
+      "schema": "",
+      "columns": {
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hyper-recipes_recipe_ingredients_recipe_id_hyper-recipes_recipes_id_fk": {
+          "name": "hyper-recipes_recipe_ingredients_recipe_id_hyper-recipes_recipes_id_fk",
+          "tableFrom": "hyper-recipes_recipe_ingredients",
+          "tableTo": "hyper-recipes_recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hyper-recipes_recipe_ingredients_ingredient_id_hyper-recipes_ingredients_id_fk": {
+          "name": "hyper-recipes_recipe_ingredients_ingredient_id_hyper-recipes_ingredients_id_fk",
+          "tableFrom": "hyper-recipes_recipe_ingredients",
+          "tableTo": "hyper-recipes_ingredients",
+          "columnsFrom": [
+            "ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hyper-recipes_recipe_ingredients_recipe_id_ingredient_id_pk": {
+          "name": "hyper-recipes_recipe_ingredients_recipe_id_ingredient_id_pk",
+          "columns": [
+            "recipe_id",
+            "ingredient_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_achievements": {
+      "name": "hyper-recipes_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "achievements_user_id_idx": {
+          "name": "achievements_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_badges": {
+      "name": "hyper-recipes_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_name": {
+          "name": "badge_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badges_user_id_idx": {
+          "name": "badges_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_points": {
+      "name": "hyper-recipes_points",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "xp_for_current_level": {
+          "name": "xp_for_current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_level_xp": {
+          "name": "next_level_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        }
+      },
+      "indexes": {
+        "points_user_id_idx": {
+          "name": "points_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_cooking_sessions": {
+      "name": "hyper-recipes_cooking_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_minutes": {
+          "name": "time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cooked_at": {
+          "name": "cooked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "cooking_sessions_recipe_id_idx": {
+          "name": "cooking_sessions_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cooking_sessions_user_id_idx": {
+          "name": "cooking_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cooking_sessions_user_recipe_idx": {
+          "name": "cooking_sessions_user_recipe_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hyper-recipes_cooking_sessions_recipe_id_hyper-recipes_recipes_id_fk": {
+          "name": "hyper-recipes_cooking_sessions_recipe_id_hyper-recipes_recipes_id_fk",
+          "tableFrom": "hyper-recipes_cooking_sessions",
+          "tableTo": "hyper-recipes_recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_collections": {
+      "name": "hyper-recipes_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_collection_recipes": {
+      "name": "hyper-recipes_collection_recipes",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "collection_recipes_collection_idx": {
+          "name": "collection_recipes_collection_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_recipes_recipe_idx": {
+          "name": "collection_recipes_recipe_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hyper-recipes_collection_recipes_collection_id_hyper-recipes_collections_id_fk": {
+          "name": "hyper-recipes_collection_recipes_collection_id_hyper-recipes_collections_id_fk",
+          "tableFrom": "hyper-recipes_collection_recipes",
+          "tableTo": "hyper-recipes_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hyper-recipes_collection_recipes_recipe_id_hyper-recipes_recipes_id_fk": {
+          "name": "hyper-recipes_collection_recipes_recipe_id_hyper-recipes_recipes_id_fk",
+          "tableFrom": "hyper-recipes_collection_recipes",
+          "tableTo": "hyper-recipes_recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hyper-recipes_collection_recipes_collection_id_recipe_id_pk": {
+          "name": "hyper-recipes_collection_recipes_collection_id_recipe_id_pk",
+          "columns": [
+            "collection_id",
+            "recipe_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_recipe_versions": {
+      "name": "hyper-recipes_recipe_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "difficulty_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_base": {
+          "name": "is_base",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hyper-recipes_recipe_versions_recipe_id_hyper-recipes_recipes_id_fk": {
+          "name": "hyper-recipes_recipe_versions_recipe_id_hyper-recipes_recipes_id_fk",
+          "tableFrom": "hyper-recipes_recipe_versions",
+          "tableTo": "hyper-recipes_recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_recipe_steps": {
+      "name": "hyper-recipes_recipe_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timer_seconds": {
+          "name": "timer_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skill_level": {
+          "name": "skill_level",
+          "type": "skill_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "techniques": {
+          "name": "techniques",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hyper-recipes_recipe_steps_version_id_hyper-recipes_recipe_versions_id_fk": {
+          "name": "hyper-recipes_recipe_steps_version_id_hyper-recipes_recipe_versions_id_fk",
+          "tableFrom": "hyper-recipes_recipe_steps",
+          "tableTo": "hyper-recipes_recipe_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_version_ingredients": {
+      "name": "hyper-recipes_version_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hyper-recipes_version_ingredients_version_id_hyper-recipes_recipe_versions_id_fk": {
+          "name": "hyper-recipes_version_ingredients_version_id_hyper-recipes_recipe_versions_id_fk",
+          "tableFrom": "hyper-recipes_version_ingredients",
+          "tableTo": "hyper-recipes_recipe_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hyper-recipes_version_ingredients_ingredient_id_hyper-recipes_ingredients_id_fk": {
+          "name": "hyper-recipes_version_ingredients_ingredient_id_hyper-recipes_ingredients_id_fk",
+          "tableFrom": "hyper-recipes_version_ingredients",
+          "tableTo": "hyper-recipes_ingredients",
+          "columnsFrom": [
+            "ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_ingredient_substitutions": {
+      "name": "hyper-recipes_ingredient_substitutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_ingredient_id": {
+          "name": "version_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substitute_ingredient_id": {
+          "name": "substitute_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substitute_quantity": {
+          "name": "substitute_quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substitute_unit": {
+          "name": "substitute_unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hyper-recipes_ingredient_substitutions_version_ingredient_id_hyper-recipes_version_ingredients_id_fk": {
+          "name": "hyper-recipes_ingredient_substitutions_version_ingredient_id_hyper-recipes_version_ingredients_id_fk",
+          "tableFrom": "hyper-recipes_ingredient_substitutions",
+          "tableTo": "hyper-recipes_version_ingredients",
+          "columnsFrom": [
+            "version_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hyper-recipes_ingredient_substitutions_substitute_ingredient_id_hyper-recipes_ingredients_id_fk": {
+          "name": "hyper-recipes_ingredient_substitutions_substitute_ingredient_id_hyper-recipes_ingredients_id_fk",
+          "tableFrom": "hyper-recipes_ingredient_substitutions",
+          "tableTo": "hyper-recipes_ingredients",
+          "columnsFrom": [
+            "substitute_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_scaling_rules": {
+      "name": "hyper-recipes_scaling_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_ingredient_id": {
+          "name": "version_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_type": {
+          "name": "rule_type",
+          "type": "scaling_rule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "factor": {
+          "name": "factor",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_servings": {
+          "name": "min_servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_servings": {
+          "name": "max_servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_size": {
+          "name": "step_size",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hyper-recipes_scaling_rules_version_ingredient_id_hyper-recipes_version_ingredients_id_fk": {
+          "name": "hyper-recipes_scaling_rules_version_ingredient_id_hyper-recipes_version_ingredients_id_fk",
+          "tableFrom": "hyper-recipes_scaling_rules",
+          "tableTo": "hyper-recipes_version_ingredients",
+          "columnsFrom": [
+            "version_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_ingredient_overrides": {
+      "name": "hyper-recipes_ingredient_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "ingredient_override_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ingredient_id": {
+          "name": "target_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_data": {
+          "name": "override_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hyper-recipes_ingredient_overrides_version_id_hyper-recipes_recipe_versions_id_fk": {
+          "name": "hyper-recipes_ingredient_overrides_version_id_hyper-recipes_recipe_versions_id_fk",
+          "tableFrom": "hyper-recipes_ingredient_overrides",
+          "tableTo": "hyper-recipes_recipe_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hyper-recipes_ingredient_overrides_target_ingredient_id_hyper-recipes_version_ingredients_id_fk": {
+          "name": "hyper-recipes_ingredient_overrides_target_ingredient_id_hyper-recipes_version_ingredients_id_fk",
+          "tableFrom": "hyper-recipes_ingredient_overrides",
+          "tableTo": "hyper-recipes_version_ingredients",
+          "columnsFrom": [
+            "target_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_step_overrides": {
+      "name": "hyper-recipes_step_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "step_override_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_step_id": {
+          "name": "target_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_data": {
+          "name": "override_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hyper-recipes_step_overrides_version_id_hyper-recipes_recipe_versions_id_fk": {
+          "name": "hyper-recipes_step_overrides_version_id_hyper-recipes_recipe_versions_id_fk",
+          "tableFrom": "hyper-recipes_step_overrides",
+          "tableTo": "hyper-recipes_recipe_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hyper-recipes_step_overrides_target_step_id_hyper-recipes_recipe_steps_id_fk": {
+          "name": "hyper-recipes_step_overrides_target_step_id_hyper-recipes_recipe_steps_id_fk",
+          "tableFrom": "hyper-recipes_step_overrides",
+          "tableTo": "hyper-recipes_recipe_steps",
+          "columnsFrom": [
+            "target_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_recipe_step_notes": {
+      "name": "hyper-recipes_recipe_step_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "step_notes_user_recipe_step_idx": {
+          "name": "step_notes_user_recipe_step_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hyper-recipes_recipe_step_notes_recipe_id_hyper-recipes_recipes_id_fk": {
+          "name": "hyper-recipes_recipe_step_notes_recipe_id_hyper-recipes_recipes_id_fk",
+          "tableFrom": "hyper-recipes_recipe_step_notes",
+          "tableTo": "hyper-recipes_recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hyper-recipes_recipe_user_notes": {
+      "name": "hyper-recipes_recipe_user_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_notes_user_recipe_idx": {
+          "name": "user_notes_user_recipe_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hyper-recipes_recipe_user_notes_recipe_id_hyper-recipes_recipes_id_fk": {
+          "name": "hyper-recipes_recipe_user_notes_recipe_id_hyper-recipes_recipes_id_fk",
+          "tableFrom": "hyper-recipes_recipe_user_notes",
+          "tableTo": "hyper-recipes_recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.tag_types": {
+      "name": "tag_types",
+      "schema": "public",
+      "values": [
+        "Cuisine",
+        "Meal",
+        "Diet"
+      ]
+    },
+    "public.difficulty_level": {
+      "name": "difficulty_level",
+      "schema": "public",
+      "values": [
+        "EASY",
+        "MEDIUM",
+        "HARD"
+      ]
+    },
+    "public.skill_level": {
+      "name": "skill_level",
+      "schema": "public",
+      "values": [
+        "beginner",
+        "intermediate",
+        "advanced"
+      ]
+    },
+    "public.scaling_rule_type": {
+      "name": "scaling_rule_type",
+      "schema": "public",
+      "values": [
+        "linear",
+        "fixed",
+        "step"
+      ]
+    },
+    "public.ingredient_override_operation": {
+      "name": "ingredient_override_operation",
+      "schema": "public",
+      "values": [
+        "ADD",
+        "REMOVE",
+        "UPDATE",
+        "REPLACE"
+      ]
+    },
+    "public.step_override_operation": {
+      "name": "step_override_operation",
+      "schema": "public",
+      "values": [
+        "ADD",
+        "REMOVE",
+        "UPDATE",
+        "REPLACE"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1767412641430,
       "tag": "0005_faulty_joseph",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1783744366179,
+      "tag": "0006_true_kid_colt",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/_actions/cookingHistory.ts
+++ b/src/app/_actions/cookingHistory.ts
@@ -3,8 +3,14 @@
 import { auth } from "@clerk/nextjs/server";
 import {
   getCookingHistoryByRecipeId,
+  getPublicCheckIns,
+  getRecipeCookStats,
+  getRecentCookingSessionsForUser,
   saveCookingSession,
   updateCookingSessionRating,
+  type PublicCheckIn,
+  type RecipeCookStats,
+  type SaveCookingSessionResult,
 } from "~/server/queries/cookingHistory";
 
 /**
@@ -23,25 +29,43 @@ export async function fetchCookingHistory(recipeId: number) {
 }
 
 /**
- * Saves a new cooking session for a recipe.
+ * Saves a new cooking session for a recipe and returns reward payload.
  * @param recipeId - The recipe ID
  * @param rating - The rating (0-5, supports half stars)
  * @param timeMinutes - The cooking time in minutes
  * @param notes - Optional notes about the cooking session
+ * @param isPublic - Whether to share with the community (default true)
+ * @returns Session id and gamification rewards
  */
 export async function saveCookingSessionAction(
   recipeId: number,
   rating: number,
   timeMinutes: number,
   notes?: string,
-): Promise<void> {
+  isPublic = true,
+): Promise<SaveCookingSessionResult> {
   const { userId } = auth();
 
   if (!userId) {
     throw new Error("User not authenticated");
   }
 
-  await saveCookingSession(recipeId, userId, rating, timeMinutes, notes);
+  if (rating < 0.5 || rating > 5) {
+    throw new Error("Rating must be between 0.5 and 5");
+  }
+
+  if (timeMinutes < 1) {
+    throw new Error("Cooking time must be at least 1 minute");
+  }
+
+  return await saveCookingSession(
+    recipeId,
+    userId,
+    rating,
+    timeMinutes,
+    notes,
+    isPublic,
+  );
 }
 
 /**
@@ -60,4 +84,43 @@ export async function updateCookingSessionRatingAction(
   }
 
   await updateCookingSessionRating(sessionId, userId, rating);
+}
+
+/**
+ * Fetches public cook stats for a recipe (no auth required).
+ * @param recipeId - The recipe ID
+ * @returns Cook count and average rating
+ */
+export async function fetchRecipeCookStats(
+  recipeId: number,
+): Promise<RecipeCookStats> {
+  return await getRecipeCookStats(recipeId);
+}
+
+/**
+ * Fetches public check-ins for a recipe (no auth required).
+ * @param recipeId - The recipe ID
+ * @param limit - Max check-ins to return
+ * @returns Public check-ins with display names
+ */
+export async function fetchPublicCheckIns(
+  recipeId: number,
+  limit = 20,
+): Promise<PublicCheckIn[]> {
+  return await getPublicCheckIns(recipeId, limit);
+}
+
+/**
+ * Fetches the current user's recent cooking sessions across recipes.
+ * @param limit - Max sessions to return
+ * @returns Recent sessions with recipe metadata
+ */
+export async function fetchMyRecentCookingSessions(limit = 10) {
+  const { userId } = auth();
+
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
+  return await getRecentCookingSessionsForUser(userId, limit);
 }

--- a/src/app/_actions/gamification.ts
+++ b/src/app/_actions/gamification.ts
@@ -7,7 +7,11 @@ import {
   addUserPoints,
   initializeUserPoints,
   setUserPoints,
+  getUserGamificationProfile,
+  getUserBadges,
 } from "~/server/queries/gamification";
+import { getUserCheckInCount } from "~/server/queries/cookingHistory";
+import { BADGE_DEFINITIONS } from "~/server/gamification/badgeDefinitions";
 
 export async function initializeUser() {
   const { userId } = auth();
@@ -29,6 +33,55 @@ export async function fetchUserProgress() {
   return await getUserProgress(userId);
 }
 
+/**
+ * Fetches progress, badges, achievements, and check-in count for Kitchen Journey.
+ */
+export async function fetchKitchenJourneyData() {
+  const { userId } = auth();
+
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
+  const [profile, progress, checkInCount] = await Promise.all([
+    getUserGamificationProfile(userId),
+    getUserProgress(userId),
+    getUserCheckInCount(userId),
+  ]);
+
+  return {
+    progress,
+    points: profile.points,
+    badges: profile.badges,
+    achievements: profile.achievements,
+    checkInCount,
+  };
+}
+
+/**
+ * Returns badge catalog with earned state for the current user.
+ */
+export async function fetchBadgeCatalog() {
+  const { userId } = auth();
+
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
+  const earned = await getUserBadges(userId);
+  const earnedNames = new Set(earned.map((b) => b.badgeName));
+
+  return BADGE_DEFINITIONS.map((badge) => ({
+    name: badge.name,
+    description: badge.description,
+    category: badge.category,
+    imagePath: badge.imagePath,
+    isEarned: earnedNames.has(badge.name),
+    earnedAt:
+      earned.find((b) => b.badgeName === badge.name)?.earnedAt ?? null,
+  }));
+}
+
 export async function awardUserPoints(points: number) {
   const { userId } = auth();
 
@@ -47,7 +100,6 @@ export async function adminSetUserPoints(targetUserId: string, points: number) {
     throw new Error("Not authenticated");
   }
 
-  // Check if the current user is an admin using the utility function
   const isAdmin = await checkRole("admin");
 
   if (!isAdmin) {
@@ -56,5 +108,3 @@ export async function adminSetUserPoints(targetUserId: string, points: number) {
 
   await setUserPoints(targetUserId, points);
 }
-
-// No need for a separate checkIfUserIsAdmin function as we're using checkRole directly

--- a/src/app/kitchen-journey/badges/page.tsx
+++ b/src/app/kitchen-journey/badges/page.tsx
@@ -1,11 +1,12 @@
-import AchievementBadge from "./_components/AchievementBadge";
-import {
-  BakingLegendBadge,
-  FirstRecipeBadge,
-  SpicyMasterBadge,
-} from "./_components/badges";
+"use client";
 
-type Badge = {
+import { useEffect, useState } from "react";
+import { useUser } from "@clerk/nextjs";
+import AchievementBadge from "./_components/AchievementBadge";
+import { fetchBadgeCatalog } from "~/app/_actions/gamification";
+import { BADGE_DEFINITIONS } from "~/server/gamification/badgeDefinitions";
+
+type BadgeRow = {
   name: string;
   description: string;
   isEarned: boolean;
@@ -13,183 +14,43 @@ type Badge = {
   imagePath: string;
 };
 
-const badges: Badge[] = [
-  // Basic Check-In Badges
-  {
-    name: "First Cook",
-    description: "Check in your first recipe",
-    isEarned: true,
-    category: "Basic Check-In Badges",
-    imagePath: "/badges/first-cook.png",
-  },
-  {
-    name: "Five-Star Chef",
-    description: "Check in 5 recipes",
-    isEarned: false,
-    category: "Basic Check-In Badges",
-    imagePath: "/badges/five-star-chef.png",
-  },
-  {
-    name: "Recipe Master",
-    description: "Check in 10 recipes",
-    isEarned: false,
-    category: "Basic Check-In Badges",
-    imagePath: "/badges/recipe-master.png",
-  },
-  {
-    name: "Kitchen Warrior",
-    description: "Check in 25 recipes",
-    isEarned: false,
-    category: "Basic Check-In Badges",
-    imagePath: "/badges/kitchen-warrior.png",
-  },
-  {
-    name: "Culinary Legend",
-    description: "Check in 50+ recipes",
-    isEarned: false,
-    category: "Basic Check-In Badges",
-    imagePath: "/badges/culinary-legend.png",
-  },
+/**
+ * Badge catalog page showing earned vs locked badges from the shared definitions.
+ */
+export default function BadgesPage(): JSX.Element {
+  const { user, isLoaded } = useUser();
+  const [badges, setBadges] = useState<BadgeRow[]>(
+    BADGE_DEFINITIONS.map((badge) => ({
+      name: badge.name,
+      description: badge.description,
+      category: badge.category,
+      imagePath: badge.imagePath,
+      isEarned: false,
+    })),
+  );
+  const [isLoading, setIsLoading] = useState(true);
 
-  // Photo Badges
-  {
-    name: "Food Photographer",
-    description: "Upload a photo for 1 check-in",
-    isEarned: false,
-    category: "Photo Badges",
-    imagePath: "/badges/food-photographer.png",
-  },
-  {
-    name: "Shutter Chef",
-    description: "Upload photos for 10 check-ins",
-    isEarned: false,
-    category: "Photo Badges",
-    imagePath: "/badges/shutter-chef.png",
-  },
-  {
-    name: "Instagram-Worthy",
-    description: "Upload high-rated photos",
-    isEarned: false,
-    category: "Photo Badges",
-    imagePath: "/badges/instagram-worthy.png",
-  },
+  useEffect(() => {
+    async function load() {
+      if (!isLoaded) return;
+      if (!user) {
+        setIsLoading(false);
+        return;
+      }
 
-  // Streak Badges
-  {
-    name: "Weekend Warrior",
-    description: "Cook 2 days in a row",
-    isEarned: false,
-    category: "Cooking Streak Badges",
-    imagePath: "/badges/weekend-warrior.png",
-  },
-  {
-    name: "One-Week Streak",
-    description: "Cook 7 days in a row",
-    isEarned: false,
-    category: "Cooking Streak Badges",
-    imagePath: "/badges/one-week-streak.png",
-  },
-  {
-    name: "Iron Chef",
-    description: "Cook 30 days in a row",
-    isEarned: false,
-    category: "Cooking Streak Badges",
-    imagePath: "/badges/iron-chef.png",
-  },
+      try {
+        const catalog = await fetchBadgeCatalog();
+        setBadges(catalog);
+      } catch (error) {
+        console.error("Failed to load badge catalog:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
 
-  // Cuisine Badges
-  {
-    name: "Italian Explorer",
-    description: "Cook 3 Italian recipes",
-    isEarned: true,
-    category: "Cuisine Badges",
-    imagePath: "/badges/italian-explorer.png",
-  },
-  {
-    name: "Masala Master",
-    description: "Cook 3 Indian recipes",
-    isEarned: true,
-    category: "Cuisine Badges",
-    imagePath: "/badges/masala-master.png",
-  },
-  {
-    name: "Sushi Sensei",
-    description: "Cook 3 Japanese recipes",
-    isEarned: true,
-    category: "Cuisine Badges",
-    imagePath: "/badges/sushi-sensei.png",
-  },
-  {
-    name: "Taco Titan",
-    description: "Cook 3 Mexican recipes",
-    isEarned: false,
-    category: "Cuisine Badges",
-    imagePath: "/badges/taco-titan.png",
-  },
-  {
-    name: "Mediterranean Maven",
-    description: "Cook 3 Mediterranean recipes",
-    isEarned: false,
-    category: "Cuisine Badges",
-    imagePath: "/badges/mediterranean-maven.png",
-  },
-  {
-    name: "Global Gourmet",
-    description: "Cook 10+ recipes from different cuisines",
-    isEarned: false,
-    category: "Cuisine Badges",
-    imagePath: "/badges/global-gourmet.png",
-  },
+    void load();
+  }, [user, isLoaded]);
 
-  // Ingredient Badges
-  {
-    name: "Garlic Lover",
-    description: "Cook 5 recipes with garlic",
-    isEarned: false,
-    category: "Ingredient Badges",
-    imagePath: "/badges/garlic-lover.png",
-  },
-  {
-    name: "Spicy Adventurer",
-    description: "Cook 3 spicy dishes",
-    isEarned: true,
-    category: "Ingredient Badges",
-    imagePath: "/badges/spicy-adventurer.png",
-  },
-  {
-    name: "Sweet Tooth",
-    description: "Cook 3 dessert recipes",
-    isEarned: false,
-    category: "Ingredient Badges",
-    imagePath: "/badges/sweet-tooth.png",
-  },
-
-  // Challenge Badges
-  {
-    name: "Speed Chef",
-    description: "Cook a recipe in under 15 minutes",
-    isEarned: false,
-    category: "Challenge Badges",
-    imagePath: "/badges/speed-chef.png",
-  },
-  {
-    name: "Clean Cook",
-    description: "Check in a recipe with zero spills",
-    isEarned: false,
-    category: "Challenge Badges",
-    imagePath: "/badges/clean-cook.png",
-  },
-  {
-    name: "Dinner Party Pro",
-    description: "Cook a meal for 4+ people",
-    isEarned: false,
-    category: "Challenge Badges",
-    imagePath: "/badges/dinner-party-pro.png",
-  },
-];
-
-export default function BadgesPage() {
-  // Group badges by category
   const groupedBadges = badges.reduce(
     (acc, badge) => {
       if (!acc[badge.category]) {
@@ -198,11 +59,22 @@ export default function BadgesPage() {
       acc[badge.category]!.push(badge);
       return acc;
     },
-    {} as Record<string, Badge[]>,
+    {} as Record<string, BadgeRow[]>,
   );
 
   return (
     <div className="container space-y-12 py-8">
+      <div className="text-center">
+        <h1 className="font-display text-3xl font-semibold">Badges</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {isLoading
+            ? "Loading your badges..."
+            : user
+              ? "Earn badges by logging cooks and exploring the kitchen."
+              : "Sign in to see which badges you have earned."}
+        </p>
+      </div>
+
       {Object.entries(groupedBadges).map(([category, categoryBadges]) => (
         <section key={category}>
           <h2 className="mb-6 text-2xl font-bold">{category}</h2>

--- a/src/app/kitchen-journey/page.tsx
+++ b/src/app/kitchen-journey/page.tsx
@@ -3,10 +3,13 @@
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { useUser } from "@clerk/nextjs";
+import { format } from "date-fns";
 import {
-  fetchUserProgress,
+  fetchKitchenJourneyData,
   adminSetUserPoints,
+  fetchUserProgress,
 } from "~/app/_actions/gamification";
+import { fetchMyRecentCookingSessions } from "~/app/_actions/cookingHistory";
 import { Input } from "~/components/ui/input";
 import { Button } from "~/components/ui/button";
 import { toast } from "sonner";
@@ -26,27 +29,42 @@ import {
   Award,
   Star,
   Clock,
-  BookOpen,
-  Heart,
   ChefHat,
   Settings,
 } from "lucide-react";
+import {
+  BADGE_DEFINITIONS,
+} from "~/server/gamification/badgeDefinitions";
 
-const KitchenJourney = () => {
-  // User progress state
+interface JourneyBadge {
+  id: number;
+  badgeName: string;
+  earnedAt: Date | string;
+}
+
+interface RecentCook {
+  id: number;
+  rating: number;
+  cookedAt: Date | string;
+  recipeName: string;
+  recipeSlug: string;
+}
+
+/**
+ * Kitchen Journey dashboard wired to real progress, badges, and cook history.
+ */
+const KitchenJourney = (): JSX.Element => {
   const [userProgress, setUserProgress] = useState({
     xp: 0,
     level: 1,
     nextLevelXp: 100,
-    recipesCreated: 0,
-    recipesFavorited: 0,
-    streakDays: 0,
+    checkInCount: 0,
+    totalPoints: 0,
   });
-  const [badges, setBadges] = useState<unknown[]>([]);
-  const [recentActivity, setRecentActivity] = useState<string[]>([]);
+  const [badges, setBadges] = useState<JourneyBadge[]>([]);
+  const [recentCooks, setRecentCooks] = useState<RecentCook[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Admin form state
   const [isAdmin, setIsAdmin] = useState(false);
   const [targetUserId, setTargetUserId] = useState("");
   const [pointsToSet, setPointsToSet] = useState(0);
@@ -55,7 +73,7 @@ const KitchenJourney = () => {
 
   const { user } = useUser();
 
-  const getRankTitle = (level: number) => {
+  const getRankTitle = (level: number): string => {
     if (level >= 10) return "Culinary Master";
     if (level >= 7) return "Kitchen Virtuoso";
     if (level >= 5) return "Culinary Expert";
@@ -63,64 +81,46 @@ const KitchenJourney = () => {
     return "Cooking Novice";
   };
 
-  const getLevelPercentage = () => {
+  const getLevelPercentage = (): number => {
     return Math.min(
       100,
       Math.round((userProgress.xp / userProgress.nextLevelXp) * 100),
     );
   };
 
+  const nextBadge = BADGE_DEFINITIONS.find(
+    (badge) =>
+      badge.checkInThreshold !== null &&
+      userProgress.checkInCount < badge.checkInThreshold,
+  );
+
   useEffect(() => {
     async function loadUserProgress() {
       try {
-        // Load progress from API
-        const progress = await fetchUserProgress();
-
-        // Extend with additional stats that would come from actual API
-        const enhancedProgress = {
-          ...progress,
-          recipesCreated: 5,
-          recipesFavorited: 8,
-          streakDays: 3,
-        };
-
-        setUserProgress(enhancedProgress);
-
-        // Fetch badges and activity (placeholder)
-        const savedBadges = JSON.parse(
-          localStorage.getItem("badges") ?? "[]",
-        ) as unknown[];
-        const savedActivity = JSON.parse(
-          localStorage.getItem("recentActivity") ?? "[]",
-        ) as string[];
-
-        // Store badges (currently unused but kept for future use)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        setBadges(savedBadges);
-        setRecentActivity([
-          "Created a new recipe: Chocolate Chip Cookies",
-          "Earned the 'First Recipe' badge",
-          "Reached Level 2!",
-          "Favorited Spaghetti Carbonara",
-          "Logged in 3 days in a row!",
+        const [journey, sessions] = await Promise.all([
+          fetchKitchenJourneyData(),
+          fetchMyRecentCookingSessions(8),
         ]);
 
-        // Check if user is admin directly from publicMetadata
+        setUserProgress({
+          xp: journey.progress.xp,
+          level: journey.progress.level,
+          nextLevelXp: journey.progress.nextLevelXp,
+          checkInCount: journey.checkInCount,
+          totalPoints: journey.points,
+        });
+        setBadges(journey.badges);
+        setRecentCooks(sessions);
+
         if (user?.publicMetadata?.role === "admin") {
           setIsAdmin(true);
-
-          // Set current user ID in the form
           if (user?.id) {
             setTargetUserId(user.id);
-            // Pre-fill with current points
-            setPointsToSet(progress.xp);
+            setPointsToSet(journey.points);
           }
-
-          // Load recent users from localStorage
           const savedRecentUsers = localStorage.getItem("recentUserIds");
           if (savedRecentUsers) {
-            const parsed = JSON.parse(savedRecentUsers) as string[];
-            setRecentUsers(parsed);
+            setRecentUsers(JSON.parse(savedRecentUsers) as string[]);
           }
         }
       } catch (error) {
@@ -132,11 +132,12 @@ const KitchenJourney = () => {
 
     if (user) {
       void loadUserProgress();
+    } else {
+      setIsLoading(false);
     }
   }, [user]);
 
-  // Admin handler to update points - update to refresh TopNav
-  const handleSetPoints = async (e: React.FormEvent) => {
+  const handleSetPoints = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
 
     if (!targetUserId.trim()) {
@@ -151,14 +152,19 @@ const KitchenJourney = () => {
         `Updated points for user ${targetUserId} to ${pointsToSet}`,
       );
 
-      // If updating own points, refresh the display
       if (targetUserId === user?.id) {
         const progress = await fetchUserProgress();
-        setUserProgress({ ...userProgress, ...progress });
+        setUserProgress((prev) => ({ ...prev, ...progress }));
       }
 
-      // Save to recent users
-      saveToRecentUsers(targetUserId);
+      if (!recentUsers.includes(targetUserId)) {
+        const updated = [
+          targetUserId,
+          ...recentUsers.filter((uid) => uid !== targetUserId).slice(0, 3),
+        ];
+        setRecentUsers(updated);
+        localStorage.setItem("recentUserIds", JSON.stringify(updated));
+      }
     } catch (error) {
       toast.error(`Failed to update points: ${(error as Error).message}`);
     } finally {
@@ -166,23 +172,22 @@ const KitchenJourney = () => {
     }
   };
 
-  // Save a user ID to the recent users list
-  const saveToRecentUsers = (id: string) => {
-    if (!id || recentUsers.includes(id)) return;
-
-    const updatedRecentUsers = [
-      id,
-      ...recentUsers.filter((uid) => uid !== id).slice(0, 3),
-    ]; // Keep max 4 users
-    setRecentUsers(updatedRecentUsers);
-    localStorage.setItem("recentUserIds", JSON.stringify(updatedRecentUsers));
-  };
+  if (!user && !isLoading) {
+    return (
+      <div className="container max-w-3xl py-16 text-center">
+        <h1 className="font-display text-3xl font-semibold">Kitchen Journey</h1>
+        <p className="mt-3 text-muted-foreground">
+          Sign in to track your cooks, XP, and badges.
+        </p>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (
       <div className="flex min-h-[400px] items-center justify-center">
         <div className="text-center">
-          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
           <p className="mt-4 text-muted-foreground">Loading your journey...</p>
         </div>
       </div>
@@ -191,12 +196,11 @@ const KitchenJourney = () => {
 
   return (
     <div className="container max-w-7xl py-8">
-      <h1 className="mb-6 text-center text-3xl font-bold">
+      <h1 className="mb-6 text-center font-display text-3xl font-semibold">
         Your Kitchen Journey
       </h1>
 
       <div className="grid gap-6 md:grid-cols-3">
-        {/* Profile Sidebar */}
         <div className="space-y-4 md:col-span-1">
           <Card>
             <CardHeader className="pb-2">
@@ -230,32 +234,21 @@ const KitchenJourney = () => {
                   <div className="text-xs text-muted-foreground">Level</div>
                 </div>
                 <div className="rounded-md bg-muted p-2">
-                  <BookOpen className="mx-auto mb-1 h-4 w-4" />
+                  <ChefHat className="mx-auto mb-1 h-4 w-4" />
                   <div className="text-xl font-bold">
-                    {userProgress.recipesCreated}
+                    {userProgress.checkInCount}
                   </div>
-                  <div className="text-xs text-muted-foreground">Recipes</div>
+                  <div className="text-xs text-muted-foreground">Cooks</div>
                 </div>
                 <div className="rounded-md bg-muted p-2">
-                  <Heart className="mx-auto mb-1 h-4 w-4" />
-                  <div className="text-xl font-bold">
-                    {userProgress.recipesFavorited}
-                  </div>
-                  <div className="text-xs text-muted-foreground">Favorites</div>
+                  <Award className="mx-auto mb-1 h-4 w-4" />
+                  <div className="text-xl font-bold">{badges.length}</div>
+                  <div className="text-xs text-muted-foreground">Badges</div>
                 </div>
               </div>
 
-              <div className="pt-2">
-                <div className="mb-1 text-sm font-medium">Current Streak</div>
-                <div className="flex items-center gap-1 text-accent">
-                  <Clock className="h-4 w-4" />
-                  <span className="font-bold">
-                    {userProgress.streakDays} days
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    &middot; Keep cooking!
-                  </span>
-                </div>
+              <div className="pt-2 text-sm text-muted-foreground">
+                {userProgress.totalPoints} total XP earned
               </div>
             </CardContent>
           </Card>
@@ -264,76 +257,79 @@ const KitchenJourney = () => {
             <CardHeader className="pb-2">
               <CardTitle className="flex items-center gap-2 text-sm">
                 <Award className="h-5 w-5 text-accent" />
-                Next Achievements
+                Next achievement
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <ul className="space-y-2 text-sm">
-                <li className="flex items-center gap-2">
+              {nextBadge ? (
+                <div className="flex items-center gap-2 text-sm">
                   <Badge
                     variant="outline"
                     className="flex h-8 w-8 items-center justify-center rounded-full p-0"
                   >
                     <Star className="h-4 w-4 text-accent" />
                   </Badge>
-                  <span>Create 5 more recipes</span>
-                </li>
-                <li className="flex items-center gap-2">
-                  <Badge
-                    variant="outline"
-                    className="flex h-8 w-8 items-center justify-center rounded-full p-0"
-                  >
-                    <Star className="h-4 w-4 text-accent" />
-                  </Badge>
-                  <span>Maintain a 7-day streak</span>
-                </li>
-              </ul>
+                  <div>
+                    <p className="font-medium">{nextBadge.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {nextBadge.description} ({userProgress.checkInCount}/
+                      {nextBadge.checkInThreshold})
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  You have earned all check-in badges. Keep cooking!
+                </p>
+              )}
             </CardContent>
             <CardFooter>
               <Link
                 href="/kitchen-journey/badges"
                 className="text-xs text-primary hover:underline"
               >
-                View all achievements
+                View all badges
               </Link>
             </CardFooter>
           </Card>
         </div>
 
-        {/* Main Content */}
         <div className="space-y-6 md:col-span-2">
           <Tabs defaultValue="activity" className="w-full">
-            <TabsList className="mb-4 grid grid-cols-3">
+            <TabsList className="mb-4 grid grid-cols-2">
               <TabsTrigger value="activity">Activity</TabsTrigger>
               <TabsTrigger value="achievements">Badges</TabsTrigger>
-              <TabsTrigger value="rewards">Rewards</TabsTrigger>
             </TabsList>
 
-            {/* Activity Tab */}
             <TabsContent value="activity">
               <Card>
                 <CardHeader>
-                  <CardTitle>Recent Activity</CardTitle>
+                  <CardTitle>Recent cooks</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  {recentActivity.length > 0 ? (
+                  {recentCooks.length > 0 ? (
                     <ul className="space-y-3">
-                      {recentActivity.map((activity, index) => (
+                      {recentCooks.map((cook) => (
                         <li
-                          key={index}
+                          key={cook.id}
                           className="flex items-start gap-3 border-b pb-3 last:border-0"
                         >
                           <div className="mt-0.5 rounded-full bg-primary/10 p-1">
                             <Clock className="h-4 w-4 text-primary" />
                           </div>
                           <div>
-                            <p className="text-sm">{activity}</p>
+                            <p className="text-sm">
+                              Cooked{" "}
+                              <Link
+                                href={`/recipe/${cook.recipeSlug}`}
+                                className="font-medium text-foreground hover:underline"
+                              >
+                                {cook.recipeName}
+                              </Link>{" "}
+                              · {cook.rating} stars
+                            </p>
                             <span className="text-xs text-muted-foreground">
-                              {index === 0
-                                ? "Just now"
-                                : index === 1
-                                  ? "Yesterday"
-                                  : `${index + 1} days ago`}
+                              {format(new Date(cook.cookedAt), "MMM d, yyyy")}
                             </span>
                           </div>
                         </li>
@@ -342,8 +338,8 @@ const KitchenJourney = () => {
                   ) : (
                     <div className="py-8 text-center text-muted-foreground">
                       <p>
-                        No activity recorded yet. Try creating or favoriting a
-                        recipe!
+                        No cooks logged yet. Finish a recipe and tap &quot;I
+                        cooked this&quot;.
                       </p>
                     </div>
                   )}
@@ -351,106 +347,49 @@ const KitchenJourney = () => {
               </Card>
             </TabsContent>
 
-            {/* Badges Tab */}
             <TabsContent value="achievements">
               <Card>
                 <CardHeader>
-                  <CardTitle>Earned Badges</CardTitle>
+                  <CardTitle>Earned badges</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="grid grid-cols-3 gap-3">
-                    {/* Sample badges - dynamically generated based on actual badges */}
-                    <div className="flex flex-col items-center text-center">
-                      <Badge className="mb-2 flex h-16 w-16 items-center justify-center rounded-full bg-accent/10 p-0 hover:bg-accent/10">
-                        <Award className="h-8 w-8" />
-                      </Badge>
-                      <span className="text-sm font-medium">First Recipe</span>
-                      <span className="text-xs text-muted-foreground">
-                        Unlocked
-                      </span>
+                  {badges.length > 0 ? (
+                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                      {badges.map((badge) => (
+                        <div
+                          key={badge.id}
+                          className="flex flex-col items-center text-center"
+                        >
+                          <Badge className="mb-2 flex h-16 w-16 items-center justify-center rounded-full bg-accent/10 p-0 hover:bg-accent/10">
+                            <Award className="h-8 w-8" />
+                          </Badge>
+                          <span className="text-sm font-medium">
+                            {badge.badgeName}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {format(new Date(badge.earnedAt), "MMM d, yyyy")}
+                          </span>
+                        </div>
+                      ))}
                     </div>
-
-                    <div className="flex flex-col items-center text-center">
-                      <Badge className="mb-2 flex h-16 w-16 items-center justify-center rounded-full bg-accent/10 p-0 hover:bg-accent/10">
-                        <Star className="h-8 w-8" />
-                      </Badge>
-                      <span className="text-sm font-medium">Level 2</span>
-                      <span className="text-xs text-muted-foreground">
-                        Unlocked
-                      </span>
-                    </div>
-
-                    {/* Locked badge example */}
-                    <div className="flex flex-col items-center text-center opacity-50">
-                      <Badge
-                        variant="outline"
-                        className="mb-2 flex h-16 w-16 items-center justify-center rounded-full p-0"
-                      >
-                        <Trophy className="h-8 w-8" />
-                      </Badge>
-                      <span className="text-sm font-medium">Expert Chef</span>
-                      <span className="text-xs text-muted-foreground">
-                        Reach level 10
-                      </span>
-                    </div>
-                  </div>
+                  ) : (
+                    <p className="py-6 text-center text-sm text-muted-foreground">
+                      Log your first cook to earn the First Cook badge.
+                    </p>
+                  )}
 
                   <div className="mt-6 text-center">
                     <Link href="/kitchen-journey/badges">
                       <Button variant="outline" size="sm">
-                        View All Badges
+                        View all badges
                       </Button>
                     </Link>
                   </div>
                 </CardContent>
               </Card>
             </TabsContent>
-
-            {/* Rewards Tab */}
-            <TabsContent value="rewards">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Rewards &amp; Unlocks</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-4">
-                    <div className="rounded-lg border border-dashed bg-muted p-4">
-                      <h3 className="mb-1 font-semibold">Pro Features</h3>
-                      <p className="mb-2 text-sm text-muted-foreground">
-                        Reach Level 5 to unlock premium recipe formats
-                      </p>
-                      <Progress
-                        value={Math.min(100, (userProgress.level / 5) * 100)}
-                        className="h-2"
-                      />
-                      <p className="mt-1 text-right text-xs text-muted-foreground">
-                        {userProgress.level}/5 Levels
-                      </p>
-                    </div>
-
-                    <div className="rounded-lg border border-dashed bg-muted p-4">
-                      <h3 className="mb-1 font-semibold">Custom Themes</h3>
-                      <p className="mb-2 text-sm text-muted-foreground">
-                        Create 10 recipes to unlock custom theme options
-                      </p>
-                      <Progress
-                        value={Math.min(
-                          100,
-                          (userProgress.recipesCreated / 10) * 100,
-                        )}
-                        className="h-2"
-                      />
-                      <p className="mt-1 text-right text-xs text-muted-foreground">
-                        {userProgress.recipesCreated}/10 Recipes
-                      </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </TabsContent>
           </Tabs>
 
-          {/* Admin Panel */}
           {isAdmin && (
             <Card className="overflow-hidden border-2 border-accent/40">
               <CardHeader className="bg-accent/10">
@@ -477,65 +416,44 @@ const KitchenJourney = () => {
                       required
                     />
                   </div>
-
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                      <label
-                        htmlFor="points"
-                        className="block text-sm font-medium"
-                      >
-                        Total XP Points
-                      </label>
-                      <Input
-                        id="points"
-                        type="number"
-                        min="0"
-                        value={pointsToSet}
-                        onChange={(e) =>
-                          setPointsToSet(parseInt(e.target.value) || 0)
-                        }
-                        placeholder="Enter new point value"
-                        required
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <label className="block text-sm font-medium text-muted-foreground">
-                        Calculated Level
-                      </label>
-                      <div className="flex h-10 items-center rounded-md border bg-muted/50 px-3 py-2">
-                        {Math.floor(Math.sqrt(pointsToSet / 25)) + 1}
-                      </div>
-                    </div>
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="points"
+                      className="block text-sm font-medium"
+                    >
+                      Points total
+                    </label>
+                    <Input
+                      id="points"
+                      type="number"
+                      value={pointsToSet}
+                      onChange={(e) =>
+                        setPointsToSet(parseInt(e.target.value, 10) || 0)
+                      }
+                      min={0}
+                      required
+                    />
                   </div>
-
-                  <Button
-                    type="submit"
-                    disabled={isUpdating}
-                    className="w-full"
-                  >
-                    {isUpdating ? "Updating..." : "Update User Points"}
+                  {recentUsers.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {recentUsers.map((id) => (
+                        <Button
+                          key={id}
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setTargetUserId(id)}
+                        >
+                          {id.slice(0, 8)}…
+                        </Button>
+                      ))}
+                    </div>
+                  )}
+                  <Button type="submit" disabled={isUpdating}>
+                    {isUpdating ? "Updating..." : "Set points"}
                   </Button>
                 </form>
               </CardContent>
-
-              {recentUsers.length > 0 && (
-                <CardFooter className="flex-col items-start border-t bg-muted/50 pt-4">
-                  <p className="mb-2 text-sm font-medium">Recent Users</p>
-                  <div className="flex flex-wrap gap-2">
-                    {recentUsers.map((id) => (
-                      <Badge
-                        key={id}
-                        variant="outline"
-                        className="cursor-pointer hover:bg-accent"
-                        onClick={() => setTargetUserId(id)}
-                      >
-                        {id === user?.id ? "Me" : id.substring(0, 8) + "..."}
-                      </Badge>
-                    ))}
-                  </div>
-                </CardFooter>
-              )}
             </Card>
           )}
         </div>

--- a/src/app/recipe/[slug]/_components/AuthGateModal.tsx
+++ b/src/app/recipe/[slug]/_components/AuthGateModal.tsx
@@ -14,17 +14,22 @@ import { Button } from "@/components/ui/button";
 interface AuthGateModalProps {
   isOpen: boolean;
   onClose: () => void;
+  title?: string;
+  description?: string;
 }
 
 /**
- * Modal gate for anonymous users attempting to use adapt controls.
- * Displays signup prompt with exact copy from spec.
+ * Modal gate for anonymous users attempting interactive features.
  * @param isOpen - Whether the modal is open
  * @param onClose - Callback to close the modal
+ * @param title - Optional custom title
+ * @param description - Optional custom description
  */
 export function AuthGateModal({
   isOpen,
   onClose,
+  title = "Unlock smart recipe controls",
+  description = "Adjust time, servings, and difficulty with a free account.",
 }: AuthGateModalProps): JSX.Element {
   const { signIn } = useSignIn();
 
@@ -44,10 +49,8 @@ export function AuthGateModal({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Unlock smart recipe controls</DialogTitle>
-          <DialogDescription>
-            Adjust time, servings, and difficulty with a free account.
-          </DialogDescription>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <DialogFooter className="flex-col gap-2 sm:flex-col">
           <Button onClick={handleCreateAccount} className="w-full">

--- a/src/app/recipe/[slug]/_components/CheckInModal.tsx
+++ b/src/app/recipe/[slug]/_components/CheckInModal.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useState } from "react";
+import { Star, StarHalf, Loader2, Trophy, Sparkles } from "lucide-react";
+import { useUser } from "@clerk/nextjs";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { saveCookingSessionAction } from "~/app/_actions/cookingHistory";
+import { AuthGateModal } from "./AuthGateModal";
+import type { CheckInRewardResult } from "~/server/queries/gamification";
+
+interface CheckInModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  recipeId: number;
+  recipeSlug: string;
+  initialTimeMinutes?: number;
+  onSuccess?: () => void;
+}
+
+/**
+ * Renders a star (full, half, or empty) for the given rating value.
+ * @param starNumber - Star position 1-5
+ * @param currentRating - Current rating value
+ * @returns Star icon element
+ */
+function renderStar(starNumber: number, currentRating: number): JSX.Element {
+  if (starNumber <= Math.floor(currentRating)) {
+    return <Star className="h-8 w-8 fill-accent text-accent" />;
+  }
+  if (starNumber - 0.5 === currentRating) {
+    return <StarHalf className="h-8 w-8 fill-accent text-accent" />;
+  }
+  return <Star className="h-8 w-8 text-muted" />;
+}
+
+/**
+ * Modal for logging a cook check-in: rating, time, notes, and share toggle.
+ * Requires authentication; shows auth gate when signed out.
+ */
+export function CheckInModal({
+  isOpen,
+  onClose,
+  recipeId,
+  initialTimeMinutes = 0,
+  onSuccess,
+}: CheckInModalProps): JSX.Element {
+  const { isSignedIn, isLoaded } = useUser();
+  const [rating, setRating] = useState(0);
+  const [hoveredRating, setHoveredRating] = useState(0);
+  const [time, setTime] = useState(
+    initialTimeMinutes > 0 ? String(initialTimeMinutes) : "",
+  );
+  const [notes, setNotes] = useState("");
+  const [isPublic, setIsPublic] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [rewards, setRewards] = useState<CheckInRewardResult | null>(null);
+  const [showAuthGate, setShowAuthGate] = useState(false);
+
+  const resetForm = (): void => {
+    setRating(0);
+    setHoveredRating(0);
+    setTime(initialTimeMinutes > 0 ? String(initialTimeMinutes) : "");
+    setNotes("");
+    setIsPublic(true);
+    setError("");
+    setRewards(null);
+    setIsSaving(false);
+  };
+
+  const handleOpenChange = (open: boolean): void => {
+    if (!open) {
+      resetForm();
+      onClose();
+    }
+  };
+
+  const handleStarClick = (star: number, event: React.MouseEvent): void => {
+    const button = event.currentTarget as HTMLButtonElement;
+    const rect = button.getBoundingClientRect();
+    const halfWidth = rect.width / 2;
+    const clickX = event.clientX - rect.left;
+    setRating(clickX < halfWidth ? star - 0.5 : star);
+  };
+
+  const handleStarHover = (star: number, event: React.MouseEvent): void => {
+    const button = event.currentTarget as HTMLButtonElement;
+    const rect = button.getBoundingClientRect();
+    const halfWidth = rect.width / 2;
+    const hoverX = event.clientX - rect.left;
+    setHoveredRating(hoverX < halfWidth ? star - 0.5 : star);
+  };
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+
+    if (!isLoaded) return;
+
+    if (!isSignedIn) {
+      setShowAuthGate(true);
+      return;
+    }
+
+    if (rating === 0) {
+      setError("Please provide a rating");
+      return;
+    }
+
+    const timeMinutes = parseInt(time, 10);
+    if (isNaN(timeMinutes) || timeMinutes < 1) {
+      setError("Please provide a valid cooking time");
+      return;
+    }
+
+    setIsSaving(true);
+    setError("");
+
+    try {
+      const result = await saveCookingSessionAction(
+        recipeId,
+        rating,
+        timeMinutes,
+        notes.trim() || undefined,
+        isPublic,
+      );
+      setRewards(result.rewards);
+      onSuccess?.();
+    } catch (err) {
+      console.error("Failed to save check-in:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to save. Please try again.",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isOpen && isLoaded && !isSignedIn) {
+    return (
+      <AuthGateModal
+        isOpen={isOpen || showAuthGate}
+        onClose={() => {
+          setShowAuthGate(false);
+          onClose();
+        }}
+        title="Log your cook"
+        description="Sign in to check in, leave a rating, and earn badges."
+      />
+    );
+  }
+
+  return (
+    <>
+      <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          {rewards ? (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Sparkles className="h-5 w-5 text-accent" aria-hidden />
+                  Cook logged
+                </DialogTitle>
+                <DialogDescription>
+                  Nice work. Your check-in is saved
+                  {isPublic ? " and shared with the community" : ""}.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-3 py-2">
+                <p className="text-sm font-medium text-foreground">
+                  +{rewards.pointsAwarded} XP
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Level {rewards.progress.level} · {rewards.progress.xp}/
+                  {rewards.progress.nextLevelXp} XP
+                </p>
+                {rewards.newBadges.length > 0 && (
+                  <ul className="space-y-2">
+                    {rewards.newBadges.map((badge) => (
+                      <li
+                        key={badge}
+                        className="flex items-center gap-2 rounded-lg border border-border/70 bg-herb-muted/40 px-3 py-2 text-sm"
+                      >
+                        <Trophy className="h-4 w-4 text-accent" aria-hidden />
+                        <span className="font-medium">{badge}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <DialogFooter>
+                <Button
+                  onClick={() => {
+                    resetForm();
+                    onClose();
+                  }}
+                  className="w-full"
+                >
+                  Done
+                </Button>
+              </DialogFooter>
+            </>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <DialogHeader>
+                <DialogTitle>I cooked this</DialogTitle>
+                <DialogDescription>
+                  Rate your cook, note what you learned, and earn XP.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-2">
+                <Label>Rating</Label>
+                <div className="flex gap-1">
+                  {[1, 2, 3, 4, 5].map((star) => (
+                    <button
+                      key={star}
+                      type="button"
+                      onClick={(e) => handleStarClick(star, e)}
+                      onMouseMove={(e) => handleStarHover(star, e)}
+                      onMouseLeave={() => setHoveredRating(0)}
+                      className="p-1 hover:text-accent"
+                      aria-label={`Rate ${star} stars`}
+                    >
+                      {renderStar(star, hoveredRating || rating)}
+                    </button>
+                  ))}
+                </div>
+                <span className="text-sm text-muted-foreground">
+                  {rating ? `${rating} stars` : "Click to rate"}
+                </span>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="check-in-time">Cooking time (minutes)</Label>
+                <Input
+                  id="check-in-time"
+                  type="number"
+                  value={time}
+                  onChange={(e) => setTime(e.target.value)}
+                  min={1}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="check-in-notes">Notes (optional)</Label>
+                <Textarea
+                  id="check-in-notes"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder="What worked well? What would you do differently?"
+                  rows={3}
+                  maxLength={2000}
+                />
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="check-in-public"
+                  checked={isPublic}
+                  onCheckedChange={(checked) => setIsPublic(checked === true)}
+                />
+                <Label
+                  htmlFor="check-in-public"
+                  className="cursor-pointer font-normal"
+                >
+                  Share with community
+                </Label>
+              </div>
+
+              {error && (
+                <p className="text-sm text-destructive" role="alert">
+                  {error}
+                </p>
+              )}
+
+              <DialogFooter>
+                <Button type="submit" disabled={isSaving} className="w-full">
+                  {isSaving ? (
+                    <>
+                      <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : (
+                    "Log this cook"
+                  )}
+                </Button>
+              </DialogFooter>
+            </form>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <AuthGateModal
+        isOpen={showAuthGate}
+        onClose={() => setShowAuthGate(false)}
+        title="Log your cook"
+        description="Sign in to check in, leave a rating, and earn badges."
+      />
+    </>
+  );
+}

--- a/src/app/recipe/[slug]/_components/CommunityCheckIns.tsx
+++ b/src/app/recipe/[slug]/_components/CommunityCheckIns.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { format } from "date-fns";
+import { Star, StarHalf, Users } from "lucide-react";
+import type { PublicCheckIn, RecipeCookStats } from "~/server/queries/cookingHistory";
+
+interface CommunityCheckInsProps {
+  stats: RecipeCookStats;
+  checkIns: PublicCheckIn[];
+}
+
+/**
+ * Renders a compact star row for a rating value.
+ * @param rating - Rating from 0-5
+ */
+function StarRating({ rating }: { rating: number }): JSX.Element {
+  return (
+    <div className="flex text-accent" aria-label={`${rating} out of 5 stars`}>
+      {[1, 2, 3, 4, 5].map((value) => {
+        const difference = value - rating;
+        if (difference <= 0) {
+          return <Star key={value} size={14} className="fill-current" />;
+        }
+        if (difference > 0 && difference < 1) {
+          return <StarHalf key={value} size={14} className="fill-current" />;
+        }
+        return <Star key={value} size={14} className="text-muted" />;
+      })}
+    </div>
+  );
+}
+
+/**
+ * Community check-ins section: aggregate stats and public cook reviews.
+ * @param stats - Aggregate cook count and average rating
+ * @param checkIns - Public check-ins with display names
+ */
+export function CommunityCheckIns({
+  stats,
+  checkIns,
+}: CommunityCheckInsProps): JSX.Element {
+  const { cookCount, avgRating } = stats;
+
+  return (
+    <section className="mt-10 space-y-5">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="font-display text-xl font-semibold tracking-tight">
+            Community cooks
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Check-ins from cooks who made this recipe.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+          {avgRating != null && (
+            <span className="flex items-center gap-1.5 font-medium text-foreground">
+              <Star className="h-4 w-4 fill-accent text-accent" aria-hidden />
+              {avgRating.toFixed(1)}
+            </span>
+          )}
+          <span className="flex items-center gap-1.5">
+            <Users className="h-4 w-4" aria-hidden />
+            {cookCount === 0
+              ? "No cooks yet"
+              : cookCount === 1
+                ? "1 cook tried this"
+                : `${cookCount} cooks tried this`}
+          </span>
+        </div>
+      </div>
+
+      {checkIns.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-border/80 bg-card/50 px-5 py-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            Be the first to cook this and share how it went.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {checkIns.map((checkIn) => (
+            <li
+              key={checkIn.id}
+              className="rounded-2xl border border-border/70 bg-card/80 px-4 py-4 sm:px-5"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-foreground">
+                    {checkIn.displayName}
+                  </span>
+                  <StarRating rating={checkIn.rating} />
+                </div>
+                <time
+                  className="text-xs text-muted-foreground"
+                  dateTime={new Date(checkIn.cookedAt).toISOString()}
+                >
+                  {format(new Date(checkIn.cookedAt), "MMM d, yyyy")}
+                </time>
+              </div>
+              {checkIn.notes && (
+                <p className="mt-2 text-sm leading-relaxed text-foreground/85">
+                  {checkIn.notes}
+                </p>
+              )}
+              <p className="mt-2 text-xs text-muted-foreground">
+                Cooked in {checkIn.timeMinutes} min
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/app/recipe/[slug]/_components/CookModeOverlay.tsx
+++ b/src/app/recipe/[slug]/_components/CookModeOverlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { X, ChevronLeft, ChevronRight, Check } from "lucide-react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { X, ChevronLeft, ChevronRight, Check, ChefHat } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "~/lib/utils";
 
@@ -19,37 +19,47 @@ interface CookModeOverlayProps {
   onClose: () => void;
   steps: string[];
   ingredients: IngredientItem[];
+  onLogCook?: (elapsedMinutes: number) => void;
 }
 
 /**
  * Full-screen cook mode with always-visible ingredients and one step at a time.
- * Desktop: ingredients sidebar + step stage. Mobile: ingredients strip above step.
- * @param isOpen - Whether cook mode is active
- * @param onClose - Callback to exit cook mode
- * @param steps - Array of step strings
- * @param ingredients - Array of ingredients for quick reference
+ * Tracks elapsed time and offers check-in when the last step is completed.
  */
 export function CookModeOverlay({
   isOpen,
   onClose,
   steps,
   ingredients,
+  onLogCook,
 }: CookModeOverlayProps): JSX.Element | null {
   const [currentStep, setCurrentStep] = useState(0);
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  const [isFinished, setIsFinished] = useState(false);
+  const startedAtRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (isOpen) {
       setCurrentStep(0);
       setCompletedSteps(new Set());
+      setIsFinished(false);
+      startedAtRef.current = Date.now();
 
       if ("wakeLock" in navigator) {
         navigator.wakeLock
           .request("screen")
           .catch((err) => console.log("Wake lock not available:", err));
       }
+    } else {
+      startedAtRef.current = null;
     }
   }, [isOpen]);
+
+  const getElapsedMinutes = (): number => {
+    if (!startedAtRef.current) return 1;
+    const elapsed = Math.round((Date.now() - startedAtRef.current) / 60000);
+    return Math.max(1, elapsed);
+  };
 
   const handleNext = useCallback((): void => {
     setCurrentStep((prev) => {
@@ -73,6 +83,7 @@ export function CookModeOverlay({
     if (!isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent): void => {
+      if (isFinished) return;
       if (e.key === "ArrowRight" || e.key === " ") {
         e.preventDefault();
         handleNext();
@@ -86,7 +97,7 @@ export function CookModeOverlay({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose, handleNext, handleBack]);
+  }, [isOpen, onClose, handleNext, handleBack, isFinished]);
 
   const handleMarkDone = (): void => {
     setCompletedSteps((prev) => {
@@ -97,7 +108,15 @@ export function CookModeOverlay({
 
     if (currentStep < steps.length - 1) {
       handleNext();
+    } else {
+      setIsFinished(true);
     }
+  };
+
+  const handleLogCook = (): void => {
+    const minutes = getElapsedMinutes();
+    onClose();
+    onLogCook?.(minutes);
   };
 
   if (!isOpen) return null;
@@ -106,7 +125,11 @@ export function CookModeOverlay({
   const isLastStep = currentStep === steps.length - 1;
   const isCurrentStepCompleted = completedSteps.has(currentStep);
   const progress =
-    steps.length > 0 ? ((currentStep + 1) / steps.length) * 100 : 0;
+    steps.length > 0
+      ? isFinished
+        ? 100
+        : ((currentStep + 1) / steps.length) * 100
+      : 0;
 
   const ingredientsList = (
     <ul className="space-y-2.5">
@@ -124,6 +147,44 @@ export function CookModeOverlay({
       )}
     </ul>
   );
+
+  if (isFinished) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col bg-background">
+        <div className="h-1 bg-muted">
+          <div className="h-full w-full bg-herb transition-all duration-300" />
+        </div>
+        <header className="flex items-center justify-end border-b border-border/70 px-4 py-3">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            <X className="mr-1.5 h-4 w-4" />
+            Exit
+          </Button>
+        </header>
+        <main className="flex flex-1 flex-col items-center justify-center px-6 py-8">
+          <div className="max-w-md text-center animate-rise space-y-4">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-herb-muted text-herb">
+              <ChefHat className="h-8 w-8" aria-hidden />
+            </div>
+            <h2 className="font-display text-3xl font-semibold tracking-tight">
+              You finished!
+            </h2>
+            <p className="text-muted-foreground">
+              Log this cook to save your rating, earn XP, and share with the
+              community.
+            </p>
+            <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:justify-center">
+              <Button onClick={handleLogCook} className="sm:min-w-[160px]">
+                Log this cook
+              </Button>
+              <Button variant="outline" onClick={onClose}>
+                Exit cook mode
+              </Button>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-background">
@@ -198,11 +259,11 @@ export function CookModeOverlay({
 
               <Button
                 onClick={handleMarkDone}
-                disabled={isCurrentStepCompleted}
+                disabled={isCurrentStepCompleted && !isLastStep}
                 className="max-w-xs flex-1"
               >
                 <Check className="mr-1.5 h-4 w-4" />
-                Done
+                {isLastStep ? "Finish" : "Done"}
               </Button>
 
               <Button

--- a/src/app/recipe/[slug]/_components/CookingHistory.tsx
+++ b/src/app/recipe/[slug]/_components/CookingHistory.tsx
@@ -1,13 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Star, StarHalf } from "lucide-react";
 import { format } from "date-fns";
@@ -25,12 +18,10 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import CookingTimer from "./CookingTimer";
 import {
   fetchCookingHistory,
   updateCookingSessionRatingAction,
 } from "~/app/_actions/cookingHistory";
-import { getRecipeIdBySlug } from "~/app/_actions/recipes";
 
 type Cook = {
   id: number;
@@ -41,28 +32,40 @@ type Cook = {
   notes: string | null;
 };
 
-function StarRating({ rating }: { rating: number }) {
+function StarRating({ rating }: { rating: number }): JSX.Element {
   return (
     <div className="flex text-accent">
       {[1, 2, 3, 4, 5].map((value) => {
         const difference = value - rating;
         if (difference <= 0) {
           return <Star key={value} size={16} className="fill-current" />;
-        } else if (difference > 0 && difference < 1) {
-          return <StarHalf key={value} size={16} className="fill-current" />;
-        } else {
-          return <Star key={value} size={16} className="text-muted" />;
         }
+        if (difference > 0 && difference < 1) {
+          return <StarHalf key={value} size={16} className="fill-current" />;
+        }
+        return <Star key={value} size={16} className="text-muted" />;
       })}
     </div>
   );
 }
 
 interface CookingHistoryProps {
-  recipeSlug: string;
+  recipeId: number;
+  refreshKey?: number;
+  onCheckIn?: () => void;
 }
 
-export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
+/**
+ * Personal cook history for the signed-in user on a recipe.
+ * @param recipeId - Recipe ID
+ * @param refreshKey - Increment to reload history after a new check-in
+ * @param onCheckIn - Opens the check-in modal
+ */
+export default function CookingHistory({
+  recipeId,
+  refreshKey = 0,
+  onCheckIn,
+}: CookingHistoryProps): JSX.Element {
   const [cooks, setCooks] = useState<Cook[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedCook, setSelectedCook] = useState<Cook | null>(null);
@@ -73,19 +76,17 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
 
   useEffect(() => {
     async function loadHistory() {
+      setIsLoading(true);
       try {
-        const recipeId = await getRecipeIdBySlug(recipeSlug);
         const sessions = await fetchCookingHistory(recipeId);
-
         const transformedCooks: Cook[] = sessions.map((session) => ({
           id: session.id,
-          date: session.cookedAt.toISOString(),
+          date: new Date(session.cookedAt).toISOString(),
           time: `${session.timeMinutes}m`,
           rating: session.rating,
           hasNotes: !!session.notes,
           notes: session.notes,
         }));
-
         setCooks(transformedCooks);
       } catch (error) {
         console.error("Failed to fetch cooking history:", error);
@@ -96,58 +97,51 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
     }
 
     void loadHistory();
-  }, [recipeSlug]);
+  }, [recipeId, refreshKey]);
 
-  const handleViewClick = (cook: Cook) => {
+  const handleViewClick = (cook: Cook): void => {
     setSelectedCook(cook);
     setEditingRating(cook.rating);
     setHoveredRating(0);
     setShowViewDialog(true);
   };
 
-  const handleStarClick = (star: number, event: React.MouseEvent) => {
-    const button = event.currentTarget;
+  const handleStarClick = (star: number, event: React.MouseEvent): void => {
+    const button = event.currentTarget as HTMLButtonElement;
     const rect = button.getBoundingClientRect();
     const halfWidth = rect.width / 2;
     const clickX = event.clientX - rect.left;
-
-    const finalRating = clickX < halfWidth ? star - 0.5 : star;
-    setEditingRating(finalRating);
+    setEditingRating(clickX < halfWidth ? star - 0.5 : star);
   };
 
-  const handleStarHover = (star: number, event: React.MouseEvent) => {
-    const button = event.currentTarget;
+  const handleStarHover = (star: number, event: React.MouseEvent): void => {
+    const button = event.currentTarget as HTMLButtonElement;
     const rect = button.getBoundingClientRect();
     const halfWidth = rect.width / 2;
     const hoverX = event.clientX - rect.left;
-
-    const finalRating = hoverX < halfWidth ? star - 0.5 : star;
-    setHoveredRating(finalRating);
+    setHoveredRating(hoverX < halfWidth ? star - 0.5 : star);
   };
 
-  const renderStar = (starNumber: number, currentRating: number) => {
+  const renderStar = (
+    starNumber: number,
+    currentRating: number,
+  ): JSX.Element => {
     if (starNumber <= Math.floor(currentRating)) {
       return <Star className="h-8 w-8 fill-accent text-accent" />;
-    } else if (starNumber - 0.5 === currentRating) {
-      return <StarHalf className="h-8 w-8 fill-accent text-accent" />;
-    } else {
-      return <Star className="h-8 w-8 text-muted" />;
     }
+    if (starNumber - 0.5 === currentRating) {
+      return <StarHalf className="h-8 w-8 fill-accent text-accent" />;
+    }
+    return <Star className="h-8 w-8 text-muted" />;
   };
 
-  const handleSaveRating = async () => {
+  const handleSaveRating = async (): Promise<void> => {
     if (!selectedCook) return;
-
-    if (editingRating === 0) {
-      alert("Please provide a rating");
-      return;
-    }
+    if (editingRating === 0) return;
 
     setIsSaving(true);
     try {
       await updateCookingSessionRatingAction(selectedCook.id, editingRating);
-
-      // Update local state
       setCooks((prevCooks) =>
         prevCooks.map((cook) =>
           cook.id === selectedCook.id
@@ -155,11 +149,9 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
             : cook,
         ),
       );
-
       setShowViewDialog(false);
     } catch (error) {
       console.error("Failed to update rating:", error);
-      alert("Failed to update rating. Please try again.");
     } finally {
       setIsSaving(false);
     }
@@ -168,65 +160,70 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
   const hasPreviousCooks = cooks.length > 0;
 
   return (
-    <Card>
-      <CardHeader className="space-y-1.5">
-        <CardTitle>Cook Tracker</CardTitle>
-        <CardDescription>
+    <div className="rounded-2xl border border-border/70 bg-card/80 p-4 sm:p-5">
+      <div className="space-y-1">
+        <h3 className="font-display text-base font-semibold tracking-tight">
+          Your cooks
+        </h3>
+        <p className="text-sm text-muted-foreground">
           {isLoading
             ? "Loading..."
             : hasPreviousCooks
               ? `Cooked ${cooks.length} ${cooks.length === 1 ? "time" : "times"}`
-              : "Ready to cook?"}
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {hasPreviousCooks && (
-          <Accordion type="single" collapsible className="mb-4">
-            <AccordionItem value="cooking-history" className="border-none">
-              <AccordionTrigger className="py-2">History</AccordionTrigger>
-              <AccordionContent>
-                <div className="space-y-2">
-                  {cooks.map((cook, i) => (
-                    <div
-                      key={i}
-                      className="flex flex-col space-y-1 border-b border-border pb-2 last:border-0"
-                    >
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm text-muted-foreground">
-                          {format(new Date(cook.date), "MMM d")}
-                        </span>
-                        <span className="text-sm">{cook.time}</span>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <StarRating rating={cook.rating} />
-                        <Button
-                          variant="link"
-                          className="h-6 p-0 text-xs"
-                          onClick={() => handleViewClick(cook)}
-                        >
-                          View
-                        </Button>
-                      </div>
+              : "You have not logged this recipe yet."}
+        </p>
+      </div>
+
+      {hasPreviousCooks && (
+        <Accordion type="single" collapsible className="mt-3">
+          <AccordionItem value="cooking-history" className="border-none">
+            <AccordionTrigger className="py-2 text-sm">History</AccordionTrigger>
+            <AccordionContent>
+              <div className="space-y-2">
+                {cooks.map((cook) => (
+                  <div
+                    key={cook.id}
+                    className="flex flex-col space-y-1 border-b border-border/60 pb-2 last:border-0"
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-muted-foreground">
+                        {format(new Date(cook.date), "MMM d")}
+                      </span>
+                      <span className="text-sm">{cook.time}</span>
                     </div>
-                  ))}
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        )}
-        <CookingTimer recipeSlug={recipeSlug} />
-      </CardContent>
+                    <div className="flex items-center justify-between">
+                      <StarRating rating={cook.rating} />
+                      <Button
+                        variant="link"
+                        className="h-6 p-0 text-xs"
+                        onClick={() => handleViewClick(cook)}
+                      >
+                        View
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
+
+      {onCheckIn && (
+        <Button onClick={onCheckIn} className="mt-4 w-full" variant="outline">
+          I cooked this
+        </Button>
+      )}
 
       <Dialog open={showViewDialog} onOpenChange={setShowViewDialog}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Cooking Session Details</DialogTitle>
+            <DialogTitle>Cooking session</DialogTitle>
             <DialogDescription>
-              View and edit your cooking session
+              View and edit your rating for this cook.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-6 py-4">
-            {/* Rating Section */}
             <div className="space-y-2">
               <label className="text-sm font-medium">Rating</label>
               <div className="flex gap-2">
@@ -248,11 +245,10 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
               </span>
             </div>
 
-            {/* Notes Section */}
             {selectedCook?.notes && (
               <div className="space-y-2">
                 <label className="text-sm font-medium">Notes</label>
-                <p className="whitespace-pre-wrap rounded-md border border-border p-3 text-sm text-foreground/80 dark:border-border dark:text-muted-foreground">
+                <p className="whitespace-pre-wrap rounded-md border border-border p-3 text-sm text-foreground/80">
                   {selectedCook.notes}
                 </p>
               </div>
@@ -267,11 +263,11 @@ export default function CookingHistory({ recipeSlug }: CookingHistoryProps) {
               Cancel
             </Button>
             <Button onClick={handleSaveRating} disabled={isSaving}>
-              {isSaving ? "Saving..." : "Save Rating"}
+              {isSaving ? "Saving..." : "Save rating"}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </Card>
+    </div>
   );
 }

--- a/src/app/recipe/[slug]/_components/FullRecipePage.tsx
+++ b/src/app/recipe/[slug]/_components/FullRecipePage.tsx
@@ -24,6 +24,9 @@ import { CookModeOverlay } from "./CookModeOverlay";
 import { MobileStickyBar } from "./MobileStickyBar";
 import { MoreLikeThis } from "./MoreLikeThis";
 import { AdminWrapper } from "./AdminWrapper";
+import { CommunityCheckIns } from "./CommunityCheckIns";
+import { CheckInModal } from "./CheckInModal";
+import CookingHistory from "./CookingHistory";
 import { checkIfFavorite, toggleFavorite } from "~/app/_actions/favorites";
 import { saveGeneralNote } from "~/app/_actions/userNotes";
 import { fetchRecipeView, onPublishRecipe } from "./actions";
@@ -31,6 +34,10 @@ import type {
   RecipeViewDTO,
   RecipeViewIngredient,
 } from "./recipeViewTypes";
+import type {
+  PublicCheckIn,
+  RecipeCookStats,
+} from "~/server/queries/cookingHistory";
 
 interface FullRecipe {
   id: number;
@@ -87,6 +94,8 @@ interface FullRecipePageProps {
   hasV2Data?: boolean;
   initialRecipeView?: RecipeViewDTO;
   userNotes?: UserNotes;
+  cookStats?: RecipeCookStats;
+  publicCheckIns?: PublicCheckIn[];
 }
 
 const DEFAULT_SERVINGS = 4;
@@ -149,14 +158,7 @@ function buildSwaps(ingredients: RecipeViewIngredient[]): IngredientSwap[] {
 }
 
 /**
- * Recipe detail page with hero photo, sticky ingredients, and tucked adapt controls.
- * @param recipe - The full recipe data
- * @param relatedRecipes - Related recipes for "More like this" section
- * @param adminEditSheet - Server component for admin edit functionality
- * @param dangerZoneDialog - Server component for danger zone dialog
- * @param hasV2Data - Whether this recipe has v2 versions
- * @param initialRecipeView - SSR-loaded MEDIUM view for v2 recipes
- * @param userNotes - Personalized notes for the signed-in user
+ * Recipe detail page with hero, cook check-ins, community reviews, and cook mode.
  */
 export function FullRecipePageClient({
   recipe,
@@ -166,6 +168,8 @@ export function FullRecipePageClient({
   hasV2Data = false,
   initialRecipeView,
   userNotes,
+  cookStats = { cookCount: 0, avgRating: null },
+  publicCheckIns = [],
 }: FullRecipePageProps): JSX.Element {
   const { isSignedIn, isLoaded } = useUser();
   const [servings, setServings] = useState(DEFAULT_SERVINGS);
@@ -185,6 +189,11 @@ export function FullRecipePageClient({
 
   const [isCookModeOpen, setIsCookModeOpen] = useState(false);
   const [isFavorite, setIsFavorite] = useState(false);
+  const [isCheckInOpen, setIsCheckInOpen] = useState(false);
+  const [checkInTimeMinutes, setCheckInTimeMinutes] = useState(0);
+  const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
+  const [localCookStats, setLocalCookStats] =
+    useState<RecipeCookStats>(cookStats);
 
   const [generalNote, setGeneralNote] = useState(userNotes?.generalNote ?? "");
   const [savedGeneralNote, setSavedGeneralNote] = useState(
@@ -254,6 +263,19 @@ export function FullRecipePageClient({
     setIsCookModeOpen(true);
   };
 
+  const openCheckIn = (elapsedMinutes = 0): void => {
+    setCheckInTimeMinutes(elapsedMinutes);
+    setIsCheckInOpen(true);
+  };
+
+  const handleCheckInSuccess = (): void => {
+    setHistoryRefreshKey((k) => k + 1);
+    setLocalCookStats((prev) => ({
+      cookCount: prev.cookCount + 1,
+      avgRating: prev.avgRating,
+    }));
+  };
+
   const handleSaveGeneralNote = useCallback(async () => {
     setGeneralNoteSaveState("saving");
     setGeneralNoteError("");
@@ -306,7 +328,9 @@ export function FullRecipePageClient({
         recipe={recipe}
         tags={tags}
         servings={servings}
+        cookStats={localCookStats}
         onStartCookMode={handleStartCookMode}
+        onCheckIn={() => openCheckIn()}
       />
 
       <div className="container py-8 lg:py-10">
@@ -343,6 +367,14 @@ export function FullRecipePageClient({
                 hasV2Data={hasV2Data}
                 defaultCollapsed
               />
+
+              <SignedIn>
+                <CookingHistory
+                  recipeId={recipe.id}
+                  refreshKey={historyRefreshKey}
+                  onCheckIn={() => openCheckIn()}
+                />
+              </SignedIn>
             </div>
           </aside>
 
@@ -356,6 +388,12 @@ export function FullRecipePageClient({
               isLoading={isViewLoading}
               swaps={swaps}
             />
+
+            <div className="mt-8 flex justify-center sm:justify-start">
+              <Button onClick={() => openCheckIn()} size="lg">
+                I cooked this
+              </Button>
+            </div>
 
             <section className="mt-10 rounded-2xl border border-border/70 bg-gradient-to-br from-card via-card to-herb-muted/40 p-5 sm:p-6">
               <h2 className="font-display text-xl font-semibold tracking-tight">
@@ -412,6 +450,11 @@ export function FullRecipePageClient({
               </div>
             </section>
 
+            <CommunityCheckIns
+              stats={localCookStats}
+              checkIns={publicCheckIns}
+            />
+
             {dangerZoneDialog && (
               <AdminWrapper>
                 <div className="mt-8">{dangerZoneDialog}</div>
@@ -429,6 +472,7 @@ export function FullRecipePageClient({
         isFavorite={isFavorite}
         onToggleFavorite={handleToggleFavorite}
         onStartCookMode={handleStartCookMode}
+        onCheckIn={() => openCheckIn()}
         servings={servings}
         onServingsChange={setServings}
         difficulty={difficulty}
@@ -441,6 +485,16 @@ export function FullRecipePageClient({
         onClose={() => setIsCookModeOpen(false)}
         steps={stepStrings}
         ingredients={displayIngredients}
+        onLogCook={(minutes) => openCheckIn(minutes)}
+      />
+
+      <CheckInModal
+        isOpen={isCheckInOpen}
+        onClose={() => setIsCheckInOpen(false)}
+        recipeId={recipe.id}
+        recipeSlug={recipe.slug}
+        initialTimeMinutes={checkInTimeMinutes}
+        onSuccess={handleCheckInSuccess}
       />
     </>
   );

--- a/src/app/recipe/[slug]/_components/FullRecipePageServer.tsx
+++ b/src/app/recipe/[slug]/_components/FullRecipePageServer.tsx
@@ -12,6 +12,10 @@ import {
   getStepNotesForRecipe,
   getGeneralNoteForRecipe,
 } from "~/server/queries/userNotes";
+import {
+  getPublicCheckIns,
+  getRecipeCookStats,
+} from "~/server/queries/cookingHistory";
 import { fetchRecipeView } from "./actions";
 import type { RecipeViewDTO } from "./recipeViewTypes";
 
@@ -32,14 +36,23 @@ export default async function FullRecipePageServer({
 }: FullRecipePageServerProps): Promise<JSX.Element> {
   const { userId } = auth();
 
-  const [fullRecipe, hasV2, relatedRows, stepNotes, generalNote] =
-    await Promise.all([
-      getFullRecipeById(id),
-      hasV2DataAsync(id),
-      getRelatedRecipeSummariesExcluding(id),
-      userId ? getStepNotesForRecipe(id) : Promise.resolve({}),
-      userId ? getGeneralNoteForRecipe(id) : Promise.resolve(""),
-    ]);
+  const [
+    fullRecipe,
+    hasV2,
+    relatedRows,
+    stepNotes,
+    generalNote,
+    cookStats,
+    publicCheckIns,
+  ] = await Promise.all([
+    getFullRecipeById(id),
+    hasV2DataAsync(id),
+    getRelatedRecipeSummariesExcluding(id),
+    userId ? getStepNotesForRecipe(id) : Promise.resolve({}),
+    userId ? getGeneralNoteForRecipe(id) : Promise.resolve(""),
+    getRecipeCookStats(id),
+    getPublicCheckIns(id),
+  ]);
 
   if (!fullRecipe.published && !userId) {
     throw new Error("Recipe is unpublished.");
@@ -111,6 +124,8 @@ export default async function FullRecipePageServer({
       hasV2Data={hasV2}
       initialRecipeView={initialRecipeView}
       userNotes={userNotes}
+      cookStats={cookStats}
+      publicCheckIns={publicCheckIns}
     />
   );
 }

--- a/src/app/recipe/[slug]/_components/MobileStickyBar.tsx
+++ b/src/app/recipe/[slug]/_components/MobileStickyBar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useUser } from "@clerk/nextjs";
-import { Bookmark, BookmarkCheck, Sliders } from "lucide-react";
+import { Bookmark, BookmarkCheck, Sliders, ChefHat } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Drawer,
@@ -19,6 +19,7 @@ interface MobileStickyBarProps {
   isFavorite: boolean;
   onToggleFavorite: () => void;
   onStartCookMode: () => void;
+  onCheckIn: () => void;
   servings: number;
   onServingsChange: (servings: number) => void;
   difficulty?: DifficultyLevel;
@@ -27,20 +28,13 @@ interface MobileStickyBarProps {
 }
 
 /**
- * Mobile sticky bottom bar with save, tucked adapt drawer, and deemphasized cook mode.
- * @param isFavorite - Whether the recipe is favorited
- * @param onToggleFavorite - Callback to toggle favorite
- * @param onStartCookMode - Callback to start cook mode
- * @param servings - Current servings
- * @param onServingsChange - Callback when servings change
- * @param difficulty - Current difficulty level (v2)
- * @param onDifficultyChange - Callback when difficulty changes (v2)
- * @param hasV2Data - Whether this recipe has v2 difficulty variations
+ * Mobile sticky bottom bar with save, check-in, adapt drawer, and cook mode.
  */
 export function MobileStickyBar({
   isFavorite,
   onToggleFavorite,
   onStartCookMode,
+  onCheckIn,
   servings,
   onServingsChange,
   difficulty,
@@ -74,16 +68,24 @@ export function MobileStickyBar({
       <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border/70 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:hidden">
         <div className="container flex items-center justify-between gap-2 px-4 py-3">
           <Button
-            onClick={handleSaveClick}
+            onClick={onCheckIn}
             className="flex-1 shadow-soft"
+            aria-label="Log that you cooked this"
+          >
+            <ChefHat className="mr-1.5 h-4 w-4" />
+            I cooked this
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={handleSaveClick}
             aria-label={isFavorite ? "Remove favorite" : "Save favorite"}
           >
             {isFavorite ? (
-              <BookmarkCheck className="mr-1.5 h-4 w-4 fill-current" />
+              <BookmarkCheck className="h-4 w-4 fill-current" />
             ) : (
-              <Bookmark className="mr-1.5 h-4 w-4" />
+              <Bookmark className="h-4 w-4" />
             )}
-            {isFavorite ? "Saved" : "Save"}
           </Button>
           <Button
             variant="outline"
@@ -99,7 +101,7 @@ export function MobileStickyBar({
             onClick={onStartCookMode}
             className="text-muted-foreground"
           >
-            Cook Mode
+            Cook
           </Button>
         </div>
       </div>

--- a/src/app/recipe/[slug]/_components/RecipeHeader.tsx
+++ b/src/app/recipe/[slug]/_components/RecipeHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { Clock, ChefHat, Users, Share2, Printer, Soup } from "lucide-react";
+import { Clock, ChefHat, Users, Share2, Printer, Soup, Star } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,6 +12,8 @@ import {
 } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { FavoriteButton } from "./FavoriteButton";
+import { AddToCollectionButton } from "./AddToCollectionButton";
+import type { RecipeCookStats } from "~/server/queries/cookingHistory";
 
 interface RecipeHeaderProps {
   recipe: {
@@ -26,7 +28,9 @@ interface RecipeHeaderProps {
   };
   tags: Array<{ id: number; name: string; tagType: string | null }>;
   servings: number;
+  cookStats?: RecipeCookStats;
   onStartCookMode: () => void;
+  onCheckIn: () => void;
 }
 
 /**
@@ -63,16 +67,14 @@ function formatDifficulty(difficulty: string | null): string | null {
 
 /**
  * Full-bleed hero header with photo, title, meta, and primary cook CTA.
- * @param recipe - The recipe data including hero image
- * @param tags - Array of recipe tags
- * @param servings - Current servings count
- * @param onStartCookMode - Opens cook mode overlay
  */
 export function RecipeHeader({
   recipe,
   tags,
   servings,
+  cookStats,
   onStartCookMode,
+  onCheckIn,
 }: RecipeHeaderProps): JSX.Element {
   const totalTime = formatTotalTime(recipe.prepTime, recipe.cookTime);
   const difficultyLabel = formatDifficulty(recipe.difficulty);
@@ -165,10 +167,24 @@ export function RecipeHeader({
               <Users className="h-4 w-4" aria-hidden />
               {servings} servings
             </span>
+            {cookStats?.avgRating != null && (
+              <span className="flex items-center gap-1.5 font-medium text-foreground">
+                <Star className="h-4 w-4 fill-accent text-accent" aria-hidden />
+                {cookStats.avgRating.toFixed(1)}
+              </span>
+            )}
+            {cookStats && cookStats.cookCount > 0 && (
+              <span className="text-sm">
+                {cookStats.cookCount === 1
+                  ? "1 cook"
+                  : `${cookStats.cookCount} cooks`}
+              </span>
+            )}
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <FavoriteButton recipeId={recipe.id} />
+            <AddToCollectionButton recipeId={recipe.id} />
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -191,6 +207,9 @@ export function RecipeHeader({
                 <TooltipContent>Print</TooltipContent>
               </Tooltip>
             </TooltipProvider>
+            <Button variant="outline" size="sm" onClick={onCheckIn}>
+              I cooked this
+            </Button>
             <Button
               variant="ghost"
               size="sm"

--- a/src/app/recipe/[slug]/rate/page.tsx
+++ b/src/app/recipe/[slug]/rate/page.tsx
@@ -1,149 +1,258 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useUser } from "@clerk/nextjs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
-import { Star, StarHalf } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Star, StarHalf, Loader2, Trophy, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { saveCookingSessionAction } from "~/app/_actions/cookingHistory";
 import { getRecipeIdBySlug } from "~/app/_actions/recipes";
+import { AuthGateModal } from "../_components/AuthGateModal";
+import type { CheckInRewardResult } from "~/server/queries/gamification";
 
+/**
+ * Renders a star icon for the rating control.
+ * @param starNumber - Star position 1-5
+ * @param currentRating - Current rating value
+ */
+function renderStar(starNumber: number, currentRating: number): JSX.Element {
+  if (starNumber <= Math.floor(currentRating)) {
+    return <Star className="h-8 w-8 fill-accent text-accent" />;
+  }
+  if (starNumber - 0.5 === currentRating) {
+    return <StarHalf className="h-8 w-8 fill-accent text-accent" />;
+  }
+  return <Star className="h-8 w-8 text-muted" />;
+}
+
+/**
+ * Deep-link fallback page for logging a cook check-in after a timed session.
+ */
 export default function RateRecipePage({
   params,
   searchParams,
 }: {
   params: { slug: string };
   searchParams: { time: string };
-}) {
+}): JSX.Element {
   const router = useRouter();
+  const { isSignedIn, isLoaded } = useUser();
   const [rating, setRating] = useState(0);
   const [hoveredRating, setHoveredRating] = useState(0);
   const [time, setTime] = useState(searchParams.time || "0");
   const [notes, setNotes] = useState("");
+  const [isPublic, setIsPublic] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [rewards, setRewards] = useState<CheckInRewardResult | null>(null);
+  const [showAuthGate, setShowAuthGate] = useState(false);
 
-  const handleStarClick = (star: number, event: React.MouseEvent) => {
-    const button = event.currentTarget;
+  useEffect(() => {
+    if (isLoaded && !isSignedIn) {
+      setShowAuthGate(true);
+    }
+  }, [isLoaded, isSignedIn]);
+
+  const handleStarClick = (star: number, event: React.MouseEvent): void => {
+    const button = event.currentTarget as HTMLButtonElement;
     const rect = button.getBoundingClientRect();
     const halfWidth = rect.width / 2;
     const clickX = event.clientX - rect.left;
-
-    // If clicked on left half, subtract 0.5
-    const finalRating = clickX < halfWidth ? star - 0.5 : star;
-    setRating(finalRating);
+    setRating(clickX < halfWidth ? star - 0.5 : star);
   };
 
-  const handleStarHover = (star: number, event: React.MouseEvent) => {
-    const button = event.currentTarget;
+  const handleStarHover = (star: number, event: React.MouseEvent): void => {
+    const button = event.currentTarget as HTMLButtonElement;
     const rect = button.getBoundingClientRect();
     const halfWidth = rect.width / 2;
     const hoverX = event.clientX - rect.left;
-
-    const finalRating = hoverX < halfWidth ? star - 0.5 : star;
-    setHoveredRating(finalRating);
+    setHoveredRating(hoverX < halfWidth ? star - 0.5 : star);
   };
 
-  const renderStar = (starNumber: number, currentRating: number) => {
-    if (starNumber <= Math.floor(currentRating)) {
-      return <Star className="h-8 w-8 fill-accent text-accent" />;
-    } else if (starNumber - 0.5 === currentRating) {
-      return <StarHalf className="h-8 w-8 fill-accent text-accent" />;
-    } else {
-      return <Star className="h-8 w-8 text-muted" />;
-    }
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
 
+    if (!isSignedIn) {
+      setShowAuthGate(true);
+      return;
+    }
+
     if (rating === 0) {
-      alert("Please provide a rating");
+      setError("Please provide a rating");
       return;
     }
 
     const timeMinutes = parseInt(time, 10);
     if (isNaN(timeMinutes) || timeMinutes < 1) {
-      alert("Please provide a valid cooking time");
+      setError("Please provide a valid cooking time");
       return;
     }
 
+    setIsSaving(true);
+    setError("");
+
     try {
       const recipeId = await getRecipeIdBySlug(params.slug);
-      await saveCookingSessionAction(
+      const result = await saveCookingSessionAction(
         recipeId,
         rating,
         timeMinutes,
-        notes || undefined,
+        notes.trim() || undefined,
+        isPublic,
       );
-      router.push(`/recipe/${params.slug}`);
-    } catch (error) {
-      console.error("Failed to save cooking session:", error);
-      alert("Failed to save rating. Please try again.");
+      setRewards(result.rewards);
+    } catch (err) {
+      console.error("Failed to save cooking session:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to save. Please try again.",
+      );
+    } finally {
+      setIsSaving(false);
     }
   };
 
+  if (rewards) {
+    return (
+      <div className="container mx-auto max-w-md space-y-8 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Sparkles className="h-5 w-5 text-accent" aria-hidden />
+              Cook logged
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm font-medium">+{rewards.pointsAwarded} XP</p>
+            <p className="text-sm text-muted-foreground">
+              Level {rewards.progress.level} · {rewards.progress.xp}/
+              {rewards.progress.nextLevelXp} XP
+            </p>
+            {rewards.newBadges.length > 0 && (
+              <ul className="space-y-2">
+                {rewards.newBadges.map((badge) => (
+                  <li
+                    key={badge}
+                    className="flex items-center gap-2 rounded-lg border border-border/70 bg-herb-muted/40 px-3 py-2 text-sm"
+                  >
+                    <Trophy className="h-4 w-4 text-accent" aria-hidden />
+                    <span className="font-medium">{badge}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <Button
+              className="w-full"
+              onClick={() => router.push(`/recipe/${params.slug}`)}
+            >
+              Back to recipe
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="container mx-auto max-w-md space-y-8 py-8"
-    >
-      <Card>
-        <CardHeader>
-          <CardTitle>Rate Your Cook</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          {/* Rating Stars */}
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Rating</label>
-            <div className="flex gap-2">
-              {[1, 2, 3, 4, 5].map((star) => (
-                <button
-                  key={star}
-                  type="button"
-                  onClick={(e) => handleStarClick(star, e)}
-                  onMouseMove={(e) => handleStarHover(star, e)}
-                  onMouseLeave={() => setHoveredRating(0)}
-                  className="p-1 hover:text-accent"
-                >
-                  {renderStar(star, hoveredRating || rating)}
-                </button>
-              ))}
+    <>
+      <form
+        onSubmit={handleSubmit}
+        className="container mx-auto max-w-md space-y-8 py-8"
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle>Rate your cook</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <Label>Rating</Label>
+              <div className="flex gap-2">
+                {[1, 2, 3, 4, 5].map((star) => (
+                  <button
+                    key={star}
+                    type="button"
+                    onClick={(e) => handleStarClick(star, e)}
+                    onMouseMove={(e) => handleStarHover(star, e)}
+                    onMouseLeave={() => setHoveredRating(0)}
+                    className="p-1 hover:text-accent"
+                  >
+                    {renderStar(star, hoveredRating || rating)}
+                  </button>
+                ))}
+              </div>
+              <span className="text-sm text-muted-foreground">
+                {rating ? `${rating} stars` : "Click to rate"}
+              </span>
             </div>
-            <span className="text-sm text-muted-foreground">
-              {rating ? `${rating} stars` : "Click to rate"}
-            </span>
-          </div>
 
-          {/* Cooking Time */}
-          <div className="space-y-2">
-            <label className="text-sm font-medium">
-              Cooking Time (minutes)
-            </label>
-            <Input
-              type="number"
-              value={time}
-              onChange={(e) => setTime(e.target.value)}
-              min="1"
-            />
-          </div>
+            <div className="space-y-2">
+              <Label htmlFor="rate-time">Cooking time (minutes)</Label>
+              <Input
+                id="rate-time"
+                type="number"
+                value={time}
+                onChange={(e) => setTime(e.target.value)}
+                min={1}
+              />
+            </div>
 
-          {/* Notes */}
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Notes (optional)</label>
-            <Textarea
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              placeholder="What worked well? What would you do differently next time?"
-              rows={4}
-            />
-          </div>
+            <div className="space-y-2">
+              <Label htmlFor="rate-notes">Notes (optional)</Label>
+              <Textarea
+                id="rate-notes"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="What worked well? What would you do differently next time?"
+                rows={4}
+              />
+            </div>
 
-          <Button type="submit" className="w-full">
-            Save Rating
-          </Button>
-        </CardContent>
-      </Card>
-    </form>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="rate-public"
+                checked={isPublic}
+                onCheckedChange={(checked) => setIsPublic(checked === true)}
+              />
+              <Label htmlFor="rate-public" className="cursor-pointer font-normal">
+                Share with community
+              </Label>
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+
+            <Button type="submit" className="w-full" disabled={isSaving}>
+              {isSaving ? (
+                <>
+                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                "Save rating"
+              )}
+            </Button>
+          </CardContent>
+        </Card>
+      </form>
+
+      <AuthGateModal
+        isOpen={showAuthGate}
+        onClose={() => {
+          setShowAuthGate(false);
+          if (!isSignedIn) {
+            router.push(`/recipe/${params.slug}`);
+          }
+        }}
+        title="Log your cook"
+        description="Sign in to check in, leave a rating, and earn badges."
+      />
+    </>
   );
 }

--- a/src/server/db/schemas/cookingHistory.ts
+++ b/src/server/db/schemas/cookingHistory.ts
@@ -1,4 +1,13 @@
-import { serial, varchar, integer, real, text, timestamp, index } from "drizzle-orm/pg-core";
+import {
+  serial,
+  varchar,
+  integer,
+  real,
+  text,
+  timestamp,
+  index,
+  boolean,
+} from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { createTable } from "../tableCreator";
 import { RecipesTable } from "./recipes";
@@ -15,6 +24,7 @@ export const CookingSessionsTable = createTable(
     rating: real("rating").notNull(),
     timeMinutes: integer("time_minutes").notNull(),
     notes: text("notes"),
+    isPublic: boolean("is_public").default(true).notNull(),
     cookedAt: timestamp("cooked_at")
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),

--- a/src/server/gamification/badgeDefinitions.ts
+++ b/src/server/gamification/badgeDefinitions.ts
@@ -1,0 +1,108 @@
+export interface BadgeDefinition {
+  name: string;
+  description: string;
+  category: string;
+  /** Minimum total check-in count required to earn this badge. Null if not count-based. */
+  checkInThreshold: number | null;
+  imagePath: string;
+}
+
+export const CHECK_IN_XP = 10;
+
+/**
+ * Badge catalog. Check-in count badges are awarded automatically on save.
+ * Other categories are defined for display but not auto-awarded yet.
+ */
+export const BADGE_DEFINITIONS: BadgeDefinition[] = [
+  {
+    name: "First Cook",
+    description: "Check in your first recipe",
+    category: "Basic Check-In Badges",
+    checkInThreshold: 1,
+    imagePath: "/badges/first-cook.png",
+  },
+  {
+    name: "Five-Star Chef",
+    description: "Check in 5 recipes",
+    category: "Basic Check-In Badges",
+    checkInThreshold: 5,
+    imagePath: "/badges/five-star-chef.png",
+  },
+  {
+    name: "Recipe Master",
+    description: "Check in 10 recipes",
+    category: "Basic Check-In Badges",
+    checkInThreshold: 10,
+    imagePath: "/badges/recipe-master.png",
+  },
+  {
+    name: "Kitchen Warrior",
+    description: "Check in 25 recipes",
+    category: "Basic Check-In Badges",
+    checkInThreshold: 25,
+    imagePath: "/badges/kitchen-warrior.png",
+  },
+  {
+    name: "Culinary Legend",
+    description: "Check in 50+ recipes",
+    category: "Basic Check-In Badges",
+    checkInThreshold: 50,
+    imagePath: "/badges/culinary-legend.png",
+  },
+  {
+    name: "Food Photographer",
+    description: "Upload a photo for 1 check-in",
+    category: "Photo Badges",
+    checkInThreshold: null,
+    imagePath: "/badges/food-photographer.png",
+  },
+  {
+    name: "Shutter Chef",
+    description: "Upload photos for 10 check-ins",
+    category: "Photo Badges",
+    checkInThreshold: null,
+    imagePath: "/badges/shutter-chef.png",
+  },
+  {
+    name: "Instagram-Worthy",
+    description: "Upload high-rated photos",
+    category: "Photo Badges",
+    checkInThreshold: null,
+    imagePath: "/badges/instagram-worthy.png",
+  },
+  {
+    name: "Weekend Warrior",
+    description: "Cook 2 days in a row",
+    category: "Cooking Streak Badges",
+    checkInThreshold: null,
+    imagePath: "/badges/weekend-warrior.png",
+  },
+  {
+    name: "One-Week Streak",
+    description: "Cook 7 days in a row",
+    category: "Cooking Streak Badges",
+    checkInThreshold: null,
+    imagePath: "/badges/one-week-streak.png",
+  },
+  {
+    name: "Iron Chef",
+    description: "Cook 30 days in a row",
+    category: "Cooking Streak Badges",
+    checkInThreshold: null,
+    imagePath: "/badges/iron-chef.png",
+  },
+];
+
+/**
+ * Returns check-in count badges the user qualifies for at a given total.
+ * @param checkInCount - Total cooking sessions for the user
+ * @returns Badge definitions that meet the threshold
+ */
+export function getEarnedCheckInBadges(
+  checkInCount: number,
+): BadgeDefinition[] {
+  return BADGE_DEFINITIONS.filter(
+    (badge) =>
+      badge.checkInThreshold !== null && checkInCount >= badge.checkInThreshold,
+  );
+}

--- a/src/server/queries/cookingHistory.ts
+++ b/src/server/queries/cookingHistory.ts
@@ -1,8 +1,32 @@
 import "server-only";
 import { db } from "../db";
-import { and, eq } from "drizzle-orm";
-import { CookingSessionsTable } from "../db/schemas";
+import { and, avg, count, desc, eq } from "drizzle-orm";
+import { CookingSessionsTable, RecipesTable } from "../db/schemas";
 import { revalidatePath } from "next/cache";
+import { clerkClient } from "@clerk/nextjs/server";
+import {
+  awardCheckInRewards,
+  type CheckInRewardResult,
+} from "./gamification";
+
+export interface RecipeCookStats {
+  cookCount: number;
+  avgRating: number | null;
+}
+
+export interface PublicCheckIn {
+  id: number;
+  rating: number;
+  timeMinutes: number;
+  notes: string | null;
+  cookedAt: Date;
+  displayName: string;
+}
+
+export interface SaveCookingSessionResult {
+  sessionId: number;
+  rewards: CheckInRewardResult;
+}
 
 /**
  * Fetches cooking history for a specific recipe and user.
@@ -24,12 +48,151 @@ export async function getCookingHistoryByRecipeId(
 }
 
 /**
- * Saves a new cooking session for a recipe.
+ * Returns aggregate cook count and average rating for a recipe.
+ * @param recipeId - The recipe ID
+ * @returns Cook stats including count and average rating
+ */
+export async function getRecipeCookStats(
+  recipeId: number,
+): Promise<RecipeCookStats> {
+  const [row] = await db
+    .select({
+      cookCount: count(),
+      avgRating: avg(CookingSessionsTable.rating),
+    })
+    .from(CookingSessionsTable)
+    .where(eq(CookingSessionsTable.recipeId, recipeId));
+
+  const cookCount = Number(row?.cookCount ?? 0);
+  const avgRaw = row?.avgRating;
+  const avgRating =
+    avgRaw == null ? null : Math.round(Number(avgRaw) * 10) / 10;
+
+  return { cookCount, avgRating };
+}
+
+/**
+ * Resolves Clerk display names for a set of user IDs.
+ * @param userIds - Unique Clerk user IDs
+ * @returns Map of userId to display name
+ */
+async function resolveDisplayNames(
+  userIds: string[],
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  if (userIds.length === 0) {
+    return names;
+  }
+
+  await Promise.all(
+    userIds.map(async (userId) => {
+      try {
+        const user = await clerkClient.users.getUser(userId);
+        const fullName = [user.firstName, user.lastName]
+          .filter(Boolean)
+          .join(" ");
+        names.set(
+          userId,
+          (fullName.length > 0 ? fullName : null) ??
+            user.username ??
+            user.emailAddresses[0]?.emailAddress ??
+            "Cook",
+        );
+      } catch {
+        names.set(userId, "Cook");
+      }
+    }),
+  );
+
+  return names;
+}
+
+/**
+ * Fetches public check-ins for a recipe with display names.
+ * @param recipeId - The recipe ID
+ * @param limit - Max number of check-ins to return
+ * @returns Public check-ins ordered by cookedAt descending
+ */
+export async function getPublicCheckIns(
+  recipeId: number,
+  limit = 20,
+): Promise<PublicCheckIn[]> {
+  const sessions = await db.query.CookingSessionsTable.findMany({
+    where: (model, { and, eq }) =>
+      and(eq(model.recipeId, recipeId), eq(model.isPublic, true)),
+    orderBy: (model, { desc }) => desc(model.cookedAt),
+    limit,
+  });
+
+  const uniqueUserIds = [...new Set(sessions.map((s) => s.userId))];
+  const displayNames = await resolveDisplayNames(uniqueUserIds);
+
+  return sessions.map((session) => ({
+    id: session.id,
+    rating: session.rating,
+    timeMinutes: session.timeMinutes,
+    notes: session.notes,
+    cookedAt: session.cookedAt,
+    displayName: displayNames.get(session.userId) ?? "Cook",
+  }));
+}
+
+/**
+ * Fetches recent cooking sessions for a user across all recipes.
+ * @param userId - The user ID
+ * @param limit - Max sessions to return
+ * @returns Recent sessions with recipe name and slug
+ */
+export async function getRecentCookingSessionsForUser(
+  userId: string,
+  limit = 10,
+) {
+  const sessions = await db
+    .select({
+      id: CookingSessionsTable.id,
+      rating: CookingSessionsTable.rating,
+      timeMinutes: CookingSessionsTable.timeMinutes,
+      notes: CookingSessionsTable.notes,
+      cookedAt: CookingSessionsTable.cookedAt,
+      recipeId: CookingSessionsTable.recipeId,
+      recipeName: RecipesTable.name,
+      recipeSlug: RecipesTable.slug,
+    })
+    .from(CookingSessionsTable)
+    .innerJoin(
+      RecipesTable,
+      eq(CookingSessionsTable.recipeId, RecipesTable.id),
+    )
+    .where(eq(CookingSessionsTable.userId, userId))
+    .orderBy(desc(CookingSessionsTable.cookedAt))
+    .limit(limit);
+
+  return sessions;
+}
+
+/**
+ * Counts total cooking sessions for a user.
+ * @param userId - The user ID
+ * @returns Total check-in count
+ */
+export async function getUserCheckInCount(userId: string): Promise<number> {
+  const [row] = await db
+    .select({ total: count() })
+    .from(CookingSessionsTable)
+    .where(eq(CookingSessionsTable.userId, userId));
+
+  return Number(row?.total ?? 0);
+}
+
+/**
+ * Saves a new cooking session and awards check-in rewards.
  * @param recipeId - The recipe ID
  * @param userId - The user ID
  * @param rating - The rating (0-5, supports half stars)
  * @param timeMinutes - The cooking time in minutes
  * @param notes - Optional notes about the cooking session
+ * @param isPublic - Whether to share with the community
+ * @returns Session id and reward payload
  */
 export async function saveCookingSession(
   recipeId: number,
@@ -37,16 +200,38 @@ export async function saveCookingSession(
   rating: number,
   timeMinutes: number,
   notes?: string,
-): Promise<void> {
-  await db.insert(CookingSessionsTable).values({
-    recipeId,
-    userId,
-    rating,
-    timeMinutes,
-    notes: notes ?? null,
+  isPublic = true,
+): Promise<SaveCookingSessionResult> {
+  const [inserted] = await db
+    .insert(CookingSessionsTable)
+    .values({
+      recipeId,
+      userId,
+      rating,
+      timeMinutes,
+      notes: notes ?? null,
+      isPublic,
+    })
+    .returning({ id: CookingSessionsTable.id });
+
+  const checkInCount = await getUserCheckInCount(userId);
+  const rewards = await awardCheckInRewards(userId, checkInCount);
+
+  const recipe = await db.query.RecipesTable.findFirst({
+    where: (model, { eq }) => eq(model.id, recipeId),
+    columns: { slug: true },
   });
 
-  revalidatePath(`/recipe/[slug]`, "page");
+  if (recipe?.slug) {
+    revalidatePath(`/recipe/${recipe.slug}`);
+  }
+  revalidatePath("/kitchen-journey");
+  revalidatePath("/kitchen-journey/badges");
+
+  return {
+    sessionId: inserted!.id,
+    rewards,
+  };
 }
 
 /**

--- a/src/server/queries/gamification.ts
+++ b/src/server/queries/gamification.ts
@@ -3,6 +3,20 @@ import { db } from "../db";
 import { revalidatePath } from "next/cache";
 import { eq } from "drizzle-orm";
 import { PointsTable, AchievementsTable, BadgesTable } from "../db/schemas";
+import {
+  CHECK_IN_XP,
+  getEarnedCheckInBadges,
+} from "~/server/gamification/badgeDefinitions";
+
+export interface CheckInRewardResult {
+  pointsAwarded: number;
+  newBadges: string[];
+  progress: {
+    xp: number;
+    level: number;
+    nextLevelXp: number;
+  };
+}
 
 // Calculate required XP for a given level
 function calculateRequiredXp(level: number): number {
@@ -216,5 +230,42 @@ export async function getUserGamificationProfile(userId: string) {
     points,
     achievements,
     badges,
+  };
+}
+
+/**
+ * Awards XP and any newly earned check-in count badges after a cook log.
+ * @param userId - The user ID
+ * @param checkInCount - Total check-ins after the new session was saved
+ * @returns Points awarded, newly earned badge names, and updated progress
+ */
+export async function awardCheckInRewards(
+  userId: string,
+  checkInCount: number,
+): Promise<CheckInRewardResult> {
+  await addUserPoints(userId, CHECK_IN_XP);
+
+  const existingBadges = await getUserBadges(userId);
+  const earnedNames = new Set(existingBadges.map((b) => b.badgeName));
+  const qualified = getEarnedCheckInBadges(checkInCount);
+  const newBadges: string[] = [];
+
+  for (const badge of qualified) {
+    if (earnedNames.has(badge.name)) {
+      continue;
+    }
+    await addUserBadge(userId, badge.name);
+    newBadges.push(badge.name);
+  }
+
+  const progress = await getUserProgress(userId);
+
+  revalidatePath("/kitchen-journey");
+  revalidatePath("/kitchen-journey/badges");
+
+  return {
+    pointsAwarded: CHECK_IN_XP,
+    newBadges,
+    progress,
   };
 }


### PR DESCRIPTION
## Summary
- Restores authenticated cook check-ins on the recipe page (rating, time, notes, share toggle) with Cook Mode finish → log flow
- Adds community check-ins, aggregate rating/cook count, personal cook history, and collections remount
- Wires XP + check-in count badges on save, and connects Kitchen Journey / badges pages to real data

## Test plan
- [ ] Sign in, open a recipe, tap **I cooked this**, submit a public check-in, confirm XP/badge celebration
- [ ] Confirm the check-in appears under Community cooks and header cook stats update after refresh
- [ ] Finish Cook Mode on the last step → Log this cook → time is prefilled
- [ ] Uncheck Share with community and confirm the entry stays in Your cooks but not Community cooks
- [ ] Signed-out user tapping check-in sees auth gate; can still read community check-ins
- [ ] Visit `/kitchen-journey` and `/kitchen-journey/badges` and confirm real progress/badges/recent cooks
- [ ] Confirm migration `0006_true_kid_colt` applied (`is_public` on cooking_sessions)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log completed cooks with ratings, cooking time, notes, and optional community sharing.
  * View recipe cook counts, average ratings, and public check-ins.
  * Earn XP and badges for cooking activity.
  * Explore Kitchen Journey progress, recent cooks, earned badges, and achievements.
  * Finish Cook Mode by logging the completed cooking session.
* **Bug Fixes**
  * Improved rating and cooking-time validation with clearer inline feedback.
  * Added authentication prompts when sign-in is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->